### PR TITLE
m4.2xlarge -> m4.xlarge

### DIFF
--- a/centos/7.4/aws/DCOS-1.11.3/docker-1.13.1/desired_cluster_profile.tfvars
+++ b/centos/7.4/aws/DCOS-1.11.3/docker-1.13.1/desired_cluster_profile.tfvars
@@ -3,9 +3,9 @@ user = "centos"
 aws_region = "us-west-2"
 
 aws_bootstrap_instance_type = "m3.large"
-aws_master_instance_type = "m4.2xlarge"
-aws_agent_instance_type = "m4.2xlarge"
-aws_public_agent_instance_type = "m4.2xlarge"
+aws_master_instance_type = "m4.xlarge"
+aws_agent_instance_type = "m4.xlarge"
+aws_public_agent_instance_type = "m4.xlarge"
 
 ssh_key_name = "dcos-images"
 # Inbound Master Access

--- a/coreos/1235.12.0/aws/DCOS-1.11.3/docker-1.12.6/desired_cluster_profile.tfvars
+++ b/coreos/1235.12.0/aws/DCOS-1.11.3/docker-1.12.6/desired_cluster_profile.tfvars
@@ -3,9 +3,9 @@ user = "core"
 aws_region = "us-west-2"
 
 aws_bootstrap_instance_type = "m3.large"
-aws_master_instance_type = "m4.2xlarge"
-aws_agent_instance_type = "m4.2xlarge"
-aws_public_agent_instance_type = "m4.2xlarge"
+aws_master_instance_type = "m4.xlarge"
+aws_agent_instance_type = "m4.xlarge"
+aws_public_agent_instance_type = "m4.xlarge"
 
 ssh_key_name = "dcos-images"
 # Inbound Master Access

--- a/coreos/1688.4.0/aws/DCOS-1.11.3/docker-17.12.1/desired_cluster_profile.tfvars
+++ b/coreos/1688.4.0/aws/DCOS-1.11.3/docker-17.12.1/desired_cluster_profile.tfvars
@@ -3,9 +3,9 @@ user = "core"
 aws_region = "us-west-2"
 
 aws_bootstrap_instance_type = "m3.large"
-aws_master_instance_type = "m4.2xlarge"
-aws_agent_instance_type = "m4.2xlarge"
-aws_public_agent_instance_type = "m4.2xlarge"
+aws_master_instance_type = "m4.xlarge"
+aws_agent_instance_type = "m4.xlarge"
+aws_public_agent_instance_type = "m4.xlarge"
 
 ssh_key_name = "dcos-images"
 # Inbound Master Access

--- a/coreos/1745.7.0/aws/DCOS-1.11.3/docker-18.03.1/desired_cluster_profile.tfvars
+++ b/coreos/1745.7.0/aws/DCOS-1.11.3/docker-18.03.1/desired_cluster_profile.tfvars
@@ -3,9 +3,9 @@ user = "core"
 aws_region = "us-west-2"
 
 aws_bootstrap_instance_type = "m3.large"
-aws_master_instance_type = "m4.2xlarge"
-aws_agent_instance_type = "m4.2xlarge"
-aws_public_agent_instance_type = "m4.2xlarge"
+aws_master_instance_type = "m4.xlarge"
+aws_agent_instance_type = "m4.xlarge"
+aws_public_agent_instance_type = "m4.xlarge"
 
 ssh_key_name = "dcos-images"
 # Inbound Master Access

--- a/coreos/835.13.0/aws/DCOS-1.11.3/docker-1.8.3/desired_cluster_profile.tfvars
+++ b/coreos/835.13.0/aws/DCOS-1.11.3/docker-1.8.3/desired_cluster_profile.tfvars
@@ -3,9 +3,9 @@ user = "core"
 aws_region = "us-west-2"
 
 aws_bootstrap_instance_type = "m3.large"
-aws_master_instance_type = "m4.2xlarge"
-aws_agent_instance_type = "m4.2xlarge"
-aws_public_agent_instance_type = "m4.2xlarge"
+aws_master_instance_type = "m4.xlarge"
+aws_agent_instance_type = "m4.xlarge"
+aws_public_agent_instance_type = "m4.xlarge"
 
 ssh_key_name = "dcos-images"
 # Inbound Master Access

--- a/oracle-linux/7.4/aws/DCOS-1.11.3/docker-1.13.1/desired_cluster_profile.tfvars
+++ b/oracle-linux/7.4/aws/DCOS-1.11.3/docker-1.13.1/desired_cluster_profile.tfvars
@@ -3,9 +3,9 @@ user = "oracle"
 aws_region = "us-west-2"
 
 aws_bootstrap_instance_type = "m3.large"
-aws_master_instance_type = "m4.2xlarge"
-aws_agent_instance_type = "m4.2xlarge"
-aws_public_agent_instance_type = "m4.2xlarge"
+aws_master_instance_type = "m4.xlarge"
+aws_agent_instance_type = "m4.xlarge"
+aws_public_agent_instance_type = "m4.xlarge"
 
 ssh_key_name = "dcos-images"
 # Inbound Master Access


### PR DESCRIPTION
we have a limit of 20 instances for m4.2xlarge instances on team13 account that we keep hitting. It's not necessary to use that type to run our tests, so we are switching to m4.xlarge. We have a limit of 1000 on those.