### PR TITLE
[WIP] Qualifying CoreOS 1800.7.0 on DC/OS 1.11.4

### DIFF
--- a/build_test_publish_images.py
+++ b/build_test_publish_images.py
@@ -213,7 +213,10 @@ def run_integration_tests(ssh_user, master_public_ips, master_private_ips, priva
     user_and_host = ssh_user + '@' + master_public_ips[0]
 
     # Running integration tests
-    subprocess.run(["ssh", "-o", "StrictHostKeyChecking=no", user_and_host, pytest_cmd], check=False, cwd=tf_dir)
+    try:
+         subprocess.run(["ssh", "-o", "StrictHostKeyChecking=no", user_and_host, pytest_cmd], check=True, cwd=tf_dir)
+     except Exception as e:
+         print(repr(e))
 
 
 def run_framework_tests(master_public_ip, tf_dir, s3_bucket='osqual-frameworks-artifacts'):

--- a/build_test_publish_images.py
+++ b/build_test_publish_images.py
@@ -214,9 +214,9 @@ def run_integration_tests(ssh_user, master_public_ips, master_private_ips, priva
 
     # Running integration tests
     try:
-         subprocess.run(["ssh", "-o", "StrictHostKeyChecking=no", user_and_host, pytest_cmd], check=True, cwd=tf_dir)
-     except Exception as e:
-         print(repr(e))
+        subprocess.run(["ssh", "-o", "StrictHostKeyChecking=no", user_and_host, pytest_cmd], check=True, cwd=tf_dir)
+    except Exception as e:
+        print(repr(e))
 
 
 def run_framework_tests(master_public_ip, tf_dir, s3_bucket='osqual-frameworks-artifacts'):

--- a/coreos/1800.7.0/aws/DCOS-1.11.4/docker-18.03.1/dcos_images.yaml
+++ b/coreos/1800.7.0/aws/DCOS-1.11.4/docker-18.03.1/dcos_images.yaml
@@ -1,0 +1,15 @@
+ap-northeast-1: ami-0e3ab6c1d720aaf87
+ap-northeast-2: ami-05ba252000022e90d
+ap-south-1: ami-0aac3bb801d22a46b
+ap-southeast-1: ami-0136c77f58160f7b3
+ap-southeast-2: ami-0cf548a45e901fafc
+ca-central-1: ami-0eda095f22b4a5ce8
+eu-central-1: ami-0026d1b27df733925
+eu-west-1: ami-0d255d7dd345c2c98
+eu-west-2: ami-02ca08604660b7f3c
+eu-west-3: ami-01cce6129ae65e277
+sa-east-1: ami-07a78bd0031f46430
+us-east-1: ami-03e76a4588155b274
+us-east-2: ami-0ea56e7e5aaa31a2d
+us-west-1: ami-006ff00843dcfbfdb
+us-west-2: ami-0bcc771cbb19ae346

--- a/coreos/1800.7.0/aws/DCOS-1.11.4/docker-18.03.1/desired_cluster_profile.tfvars
+++ b/coreos/1800.7.0/aws/DCOS-1.11.4/docker-18.03.1/desired_cluster_profile.tfvars
@@ -1,0 +1,16 @@
+os = "coreos"
+user = "core"
+aws_region = "us-west-2"
+
+aws_bootstrap_instance_type = "m3.large"
+aws_master_instance_type = "m4.xlarge"
+aws_agent_instance_type = "m4.xlarge"
+aws_public_agent_instance_type = "m4.xlarge"
+
+ssh_key_name = "dcos-images"
+# Inbound Master Access
+admin_cidr = "0.0.0.0/0"
+
+num_of_masters = "1"
+num_of_private_agents = "5"
+num_of_public_agents = "1"

--- a/coreos/1800.7.0/aws/DCOS-1.11.4/docker-18.03.1/install_dcos_prerequisites.sh
+++ b/coreos/1800.7.0/aws/DCOS-1.11.4/docker-18.03.1/install_dcos_prerequisites.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+sudo systemctl disable locksmithd
+sudo systemctl stop locksmithd
+sudo systemctl restart docker # Restarting docker to ensure its ready. Seems like its not during first usage.

--- a/coreos/1800.7.0/aws/DCOS-1.11.4/docker-18.03.1/packer.json
+++ b/coreos/1800.7.0/aws/DCOS-1.11.4/docker-18.03.1/packer.json
@@ -1,0 +1,56 @@
+{
+  "variables": {
+    "aws_access_key": "{{env `AWS_ACCESS_KEY_ID`}}",
+    "aws_secret_key": "{{env `AWS_SECRET_ACCESS_KEY`}}",
+    "region":         "us-west-2"
+  },
+  "builders": [
+    {
+      "type": "amazon-ebs",
+      "instance_type": "m4.xlarge",
+      "source_ami": "ami-662f6d1e",
+      "region": "us-west-2",
+      "access_key": "{{user `aws_access_key`}}",
+      "secret_key": "{{user `aws_secret_key`}}",
+      "ssh_username": "core",
+      "ami_name": "dcos-ami-{{timestamp}}",
+      "ami_description": "coreos/1745.7.0/aws/DCOS-1.11.3/docker-18.03.1",
+      "ami_regions": [
+        "ap-northeast-1",
+        "ap-northeast-2",
+        "ap-south-1",
+        "ap-southeast-1",
+        "ap-southeast-2",
+        "ca-central-1",
+        "eu-central-1",
+        "eu-west-1",
+        "eu-west-2",
+        "eu-west-3",
+        "sa-east-1",
+        "us-east-1",
+        "us-east-2",
+        "us-west-1",
+        "us-west-2"
+      ],
+      "ami_groups": "all",
+      "ebs_optimized": true,
+      "ena_support": true,
+      "sriov_support": true
+    }
+  ],
+  "provisioners": [
+    {
+      "type": "shell",
+      "script": "./install_dcos_prerequisites.sh"
+    }
+  ],
+  "post-processors": [
+    [
+      {
+        "output": "packer_build_history.json",
+        "strip_path": true,
+        "type": "manifest"
+      }
+    ]
+  ]
+}

--- a/coreos/1800.7.0/aws/DCOS-1.11.4/docker-18.03.1/packer_build_history.json
+++ b/coreos/1800.7.0/aws/DCOS-1.11.4/docker-18.03.1/packer_build_history.json
@@ -1,0 +1,13 @@
+{
+  "builds": [
+    {
+      "name": "amazon-ebs",
+      "builder_type": "amazon-ebs",
+      "build_time": 1535400973,
+      "files": null,
+      "artifact_id": "ap-northeast-1:ami-0e3ab6c1d720aaf87,ap-northeast-2:ami-05ba252000022e90d,ap-south-1:ami-0aac3bb801d22a46b,ap-southeast-1:ami-0136c77f58160f7b3,ap-southeast-2:ami-0cf548a45e901fafc,ca-central-1:ami-0eda095f22b4a5ce8,eu-central-1:ami-0026d1b27df733925,eu-west-1:ami-0d255d7dd345c2c98,eu-west-2:ami-02ca08604660b7f3c,eu-west-3:ami-01cce6129ae65e277,sa-east-1:ami-07a78bd0031f46430,us-east-1:ami-03e76a4588155b274,us-east-2:ami-0ea56e7e5aaa31a2d,us-west-1:ami-006ff00843dcfbfdb,us-west-2:ami-0bcc771cbb19ae346",
+      "packer_run_uuid": "5d1dc6b7-829c-8cf9-b61d-45f456fa7de6"
+    }
+  ],
+  "last_run_uuid": "5d1dc6b7-829c-8cf9-b61d-45f456fa7de6"
+}

--- a/coreos/1800.7.0/aws/DCOS-1.11.4/docker-18.03.1/publish_and_test_config.yaml
+++ b/coreos/1800.7.0/aws/DCOS-1.11.4/docker-18.03.1/publish_and_test_config.yaml
@@ -1,0 +1,2 @@
+# options: packer_build, dcos_installation, integration_tests, never. Default is dcos_installation. For more details, see README
+publish_dcos_images_after: integration_tests

--- a/coreos/1800.7.0/aws/DCOS-1.11.4/docker-18.03.1/setup.sh
+++ b/coreos/1800.7.0/aws/DCOS-1.11.4/docker-18.03.1/setup.sh
@@ -1,0 +1,1 @@
+#!/usr/bin/env bash

--- a/coreos/1800.7.0/aws/DCOS-1.11.4/docker-18.03.1/setup.sh
+++ b/coreos/1800.7.0/aws/DCOS-1.11.4/docker-18.03.1/setup.sh
@@ -1,1 +1,9 @@
 #!/usr/bin/env bash
+sudo systemctl disable locksmithd
+sudo systemctl stop locksmithd
+sudo systemctl mask locksmithd
+
+sudo systemctl disable update-engine # Disabling automatic updates.
+sudo systemctl stop update-engine
+sudo systemctl mask update-engine
+sudo systemctl restart docker # Restarting docker to ensure its ready. Seems like its not during first usage

--- a/coreos/1800.7.0/aws/base_images.json
+++ b/coreos/1800.7.0/aws/base_images.json
@@ -1,0 +1,20 @@
+{
+  "us-gov-west-1": "ami-1fc6597e",
+  "ap-northeast-2": "ami-0ee8ead7a56410bf9",
+  "sa-east-1": "ami-04a7ebb302d65e89c",
+  "eu-west-2": "ami-00985bd8806d05c41",
+  "us-west-2": "ami-09e088627f26fd7ec",
+  "eu-central-1": "ami-03ee0a0310474a00e",
+  "us-east-1": "ami-00cc4337762ba4a52",
+  "us-east-2": "ami-0bb4f3b6a361ca725",
+  "ca-central-1": "ami-3423ae50",
+  "ap-southeast-1": "ami-019daec4f68b5010b",
+  "ap-northeast-1": "ami-0c381f2f14ecc78f7",
+  "ap-south-1": "ami-07a2cf92cba794c86",
+  "eu-west-3": "ami-004dbd1511bc95349",
+  "cn-north-1": "ami-0d5ec5d735beb907e",
+  "cn-northwest-1": "ami-02a5768104b4e8d4c",
+  "eu-west-1": "ami-02e92935e00c60cf0",
+  "ap-southeast-2": "ami-054c3b6bd4def7efd",
+  "us-west-1": "ami-03a95800c211ab99d"
+}


### PR DESCRIPTION
Retrieved CoreOS 1800.7.0 AMIs from here: 
https://stable.release.core-os.net/amd64-usr/1800.7.0/coreos_production_ami_hvm.txt