### PR TITLE
Removing dcos_version parameter from terraform cluster profile.

### DIFF
--- a/build_test_publish_images.py
+++ b/build_test_publish_images.py
@@ -362,8 +362,7 @@ def _write_dcos_version_to_cluster_profile(build_dir, tf_dir):
     url = "https://downloads.dcos.io/dcos/{}/dcos_generate_config.sh"
     dcos_download_url = url.format('testing/' + dcos_version) if dcos_version == 'master' else url.format(
         'stable/' + dcos_version)
-    with open(os.path.join(tf_dir, 'desired_cluster_profile.tfvars'), "a") as f:
-        f.write('\ndcos_version = "{}"\n'.format(dcos_version))
+    with open(os.path.join(tf_dir, 'desired_cluster_profile.tfvars'), "a") as f:R
         f.write('custom_dcos_download_path = "{}"\n'.format(dcos_download_url))
 
 

--- a/build_test_publish_images.py
+++ b/build_test_publish_images.py
@@ -362,7 +362,7 @@ def _write_dcos_version_to_cluster_profile(build_dir, tf_dir):
     url = "https://downloads.dcos.io/dcos/{}/dcos_generate_config.sh"
     dcos_download_url = url.format('testing/' + dcos_version) if dcos_version == 'master' else url.format(
         'stable/' + dcos_version)
-    with open(os.path.join(tf_dir, 'desired_cluster_profile.tfvars'), "a") as f:R
+    with open(os.path.join(tf_dir, 'desired_cluster_profile.tfvars'), "a") as f:
         f.write('custom_dcos_download_path = "{}"\n'.format(dcos_download_url))
 
 


### PR DESCRIPTION
Having `dcos_version` & `dcos_download_path` in the cluster profile is redundant. Solely depending on `dcos_download_path` to install a specific DC/OS version is enough. 