### PR TITLE
Qualifying DC/OS 1.10.8 against CoreOS 1855.4.0

### DIFF
--- a/coreos/1855.4.0/aws/DCOS-1.10.8/docker-18.06.1/dcos_images.yaml
+++ b/coreos/1855.4.0/aws/DCOS-1.10.8/docker-18.06.1/dcos_images.yaml
@@ -1,0 +1,15 @@
+ap-northeast-1: ami-006850153181cf03d
+ap-northeast-2: ami-08a7e53de27b3a0ee
+ap-south-1: ami-03fe1a1bc2d03918e
+ap-southeast-1: ami-088ea4f17a3795f28
+ap-southeast-2: ami-06b5b7b72934a145c
+ca-central-1: ami-028077d13ac096a34
+eu-central-1: ami-079b3aec74bb5f5c2
+eu-west-1: ami-0fe64eed6300c98ed
+eu-west-2: ami-0d89d47e611c3a9f1
+eu-west-3: ami-02c7abee931c95ae2
+sa-east-1: ami-020712f564ba3bd64
+us-east-1: ami-082a165f8ff67595e
+us-east-2: ami-0c20ced0bab4192f4
+us-west-1: ami-061c560bad1bd343f
+us-west-2: ami-04a63b92fc68b466d

--- a/coreos/1855.4.0/aws/DCOS-1.10.8/docker-18.06.1/desired_cluster_profile.tfvars
+++ b/coreos/1855.4.0/aws/DCOS-1.10.8/docker-18.06.1/desired_cluster_profile.tfvars
@@ -1,0 +1,16 @@
+os = "coreos"
+user = "core"
+aws_region = "us-west-2"
+
+aws_bootstrap_instance_type = "m3.large"
+aws_master_instance_type = "m4.xlarge"
+aws_agent_instance_type = "m4.xlarge"
+aws_public_agent_instance_type = "m4.xlarge"
+
+ssh_key_name = "dcos-images"
+# Inbound Master Access
+admin_cidr = "0.0.0.0/0"
+
+num_of_masters = "1"
+num_of_private_agents = "5"
+num_of_public_agents = "1"

--- a/coreos/1855.4.0/aws/DCOS-1.10.8/docker-18.06.1/install_dcos_prerequisites.sh
+++ b/coreos/1855.4.0/aws/DCOS-1.10.8/docker-18.06.1/install_dcos_prerequisites.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+sudo systemctl disable locksmithd
+sudo systemctl stop locksmithd
+sudo systemctl restart docker # Restarting docker to ensure its ready. Seems like its not during first usage.

--- a/coreos/1855.4.0/aws/DCOS-1.10.8/docker-18.06.1/packer.json
+++ b/coreos/1855.4.0/aws/DCOS-1.10.8/docker-18.06.1/packer.json
@@ -8,13 +8,13 @@
     {
       "type": "amazon-ebs",
       "instance_type": "m4.xlarge",
-      "source_ami": "ami-662f6d1e",
+      "source_ami": "ami-02dea79d6a7f53d15",
       "region": "us-west-2",
       "access_key": "{{user `aws_access_key`}}",
       "secret_key": "{{user `aws_secret_key`}}",
       "ssh_username": "core",
       "ami_name": "dcos-ami-{{timestamp}}",
-      "ami_description": "coreos/1745.7.0/aws/DCOS-1.11.3/docker-18.03.1",
+      "ami_description": "coreos/1855.4.0/aws/DCOS-1.10.8/docker-18.06.1",
       "ami_regions": [
         "ap-northeast-1",
         "ap-northeast-2",

--- a/coreos/1855.4.0/aws/DCOS-1.10.8/docker-18.06.1/packer.json
+++ b/coreos/1855.4.0/aws/DCOS-1.10.8/docker-18.06.1/packer.json
@@ -1,0 +1,56 @@
+{
+  "variables": {
+    "aws_access_key": "{{env `AWS_ACCESS_KEY_ID`}}",
+    "aws_secret_key": "{{env `AWS_SECRET_ACCESS_KEY`}}",
+    "region":         "us-west-2"
+  },
+  "builders": [
+    {
+      "type": "amazon-ebs",
+      "instance_type": "m4.xlarge",
+      "source_ami": "ami-662f6d1e",
+      "region": "us-west-2",
+      "access_key": "{{user `aws_access_key`}}",
+      "secret_key": "{{user `aws_secret_key`}}",
+      "ssh_username": "core",
+      "ami_name": "dcos-ami-{{timestamp}}",
+      "ami_description": "coreos/1745.7.0/aws/DCOS-1.11.3/docker-18.03.1",
+      "ami_regions": [
+        "ap-northeast-1",
+        "ap-northeast-2",
+        "ap-south-1",
+        "ap-southeast-1",
+        "ap-southeast-2",
+        "ca-central-1",
+        "eu-central-1",
+        "eu-west-1",
+        "eu-west-2",
+        "eu-west-3",
+        "sa-east-1",
+        "us-east-1",
+        "us-east-2",
+        "us-west-1",
+        "us-west-2"
+      ],
+      "ami_groups": "all",
+      "ebs_optimized": true,
+      "ena_support": true,
+      "sriov_support": true
+    }
+  ],
+  "provisioners": [
+    {
+      "type": "shell",
+      "script": "./install_dcos_prerequisites.sh"
+    }
+  ],
+  "post-processors": [
+    [
+      {
+        "output": "packer_build_history.json",
+        "strip_path": true,
+        "type": "manifest"
+      }
+    ]
+  ]
+}

--- a/coreos/1855.4.0/aws/DCOS-1.10.8/docker-18.06.1/packer_build_history.json
+++ b/coreos/1855.4.0/aws/DCOS-1.10.8/docker-18.06.1/packer_build_history.json
@@ -1,0 +1,13 @@
+{
+  "builds": [
+    {
+      "name": "amazon-ebs",
+      "builder_type": "amazon-ebs",
+      "build_time": 1537546981,
+      "files": null,
+      "artifact_id": "ap-northeast-1:ami-006850153181cf03d,ap-northeast-2:ami-08a7e53de27b3a0ee,ap-south-1:ami-03fe1a1bc2d03918e,ap-southeast-1:ami-088ea4f17a3795f28,ap-southeast-2:ami-06b5b7b72934a145c,ca-central-1:ami-028077d13ac096a34,eu-central-1:ami-079b3aec74bb5f5c2,eu-west-1:ami-0fe64eed6300c98ed,eu-west-2:ami-0d89d47e611c3a9f1,eu-west-3:ami-02c7abee931c95ae2,sa-east-1:ami-020712f564ba3bd64,us-east-1:ami-082a165f8ff67595e,us-east-2:ami-0c20ced0bab4192f4,us-west-1:ami-061c560bad1bd343f,us-west-2:ami-04a63b92fc68b466d",
+      "packer_run_uuid": "0ab8ba25-13b5-0397-c564-97402f7cad46"
+    }
+  ],
+  "last_run_uuid": "0ab8ba25-13b5-0397-c564-97402f7cad46"
+}

--- a/coreos/1855.4.0/aws/DCOS-1.10.8/docker-18.06.1/publish_and_test_config.yaml
+++ b/coreos/1855.4.0/aws/DCOS-1.10.8/docker-18.06.1/publish_and_test_config.yaml
@@ -1,0 +1,4 @@
+# options: packer_build, dcos_installation, integration_tests, never. Default is dcos_installation. For more details, see README
+publish_dcos_images_after: dcos_installation
+run_framework_tests: true
+run_integration_tests: true

--- a/coreos/1855.4.0/aws/DCOS-1.10.8/docker-18.06.1/setup.sh
+++ b/coreos/1855.4.0/aws/DCOS-1.10.8/docker-18.06.1/setup.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+sudo systemctl disable locksmithd
+sudo systemctl stop locksmithd
+sudo systemctl mask locksmithd
+
+sudo systemctl disable update-engine # Disabling automatic updates.
+sudo systemctl stop update-engine
+sudo systemctl mask update-engine
+sudo systemctl restart docker # Restarting docker to ensure its ready. Seems like its not during first usage

--- a/coreos/1855.4.0/aws/base_images.json
+++ b/coreos/1855.4.0/aws/base_images.json
@@ -1,0 +1,20 @@
+{
+  "us-gov-west-1": "ami-98db42f9",
+  "ap-northeast-2": "ami-085e4381942bede7d",
+  "sa-east-1": "ami-09ffd65c1a16012de",
+  "eu-west-2": "ami-02de9d47add3bab7c",
+  "us-west-2": "ami-02dea79d6a7f53d15",
+  "eu-central-1": "ami-0b088568a857b7c27",
+  "us-east-1": "ami-08eda98e6fe1f83d6",
+  "us-east-2": "ami-093e794c03f1534e4",
+  "ca-central-1": "ami-0a984ec3ead59581c",
+  "ap-southeast-1": "ami-0b47d43598dba794f",
+  "ap-northeast-1": "ami-086eb64b7f4485a72",
+  "ap-south-1": "ami-0e920ea4c7e29a7ed",
+  "eu-west-3": "ami-0b8c0daca01d23eaa",
+  "cn-north-1": "ami-00307a08b617fb95f",
+  "cn-northwest-1": "ami-0c0a607177f68f8c4",
+  "eu-west-1": "ami-099b2d1bdd27b4649",
+  "ap-southeast-2": "ami-0609bb67692e98973",
+  "us-west-1": "ami-0a86d340ea7fde077"
+}


### PR DESCRIPTION
JIRA: https://jira.mesosphere.com/browse/DCOS-42008
`Results: 9 failed, 100 passed, 5 skipped, 1 pytest-warnings in 10742.71 seconds`

Closing this PR as the networking fix for this is going into DC/OS 1.10.10