### PR TITLE
[BLOCKED] Qualifying DC/OS 1.10.8 on CoreOS 1800.7.0

### DIFF
--- a/build_test_publish_images.py
+++ b/build_test_publish_images.py
@@ -220,7 +220,10 @@ def run_integration_tests(ssh_user, master_public_ips, master_private_ips, priva
     user_and_host = ssh_user + '@' + master_public_ips[0]
 
     # Running integration tests
-    subprocess.run(["ssh", "-o", "StrictHostKeyChecking=no", user_and_host, pytest_cmd], check=False, cwd=tf_dir)
+    try:
+        subprocess.run(["ssh", "-o", "StrictHostKeyChecking=no", user_and_host, pytest_cmd], check=False, cwd=tf_dir)
+    except Exception as e:
+        print(repr(e))
 
 
 def run_framework_tests(master_public_ip, tf_dir, s3_bucket='osqual-frameworks-artifacts'):

--- a/build_test_publish_images.py
+++ b/build_test_publish_images.py
@@ -220,10 +220,7 @@ def run_integration_tests(ssh_user, master_public_ips, master_private_ips, priva
     user_and_host = ssh_user + '@' + master_public_ips[0]
 
     # Running integration tests
-    try:
-        subprocess.run(["ssh", "-o", "StrictHostKeyChecking=no", user_and_host, pytest_cmd], check=False, cwd=tf_dir)
-    except Exception as e:
-        print(repr(e))
+    subprocess.run(["ssh", "-o", "StrictHostKeyChecking=no", user_and_host, pytest_cmd], check=False, cwd=tf_dir)
 
 
 def run_framework_tests(master_public_ip, tf_dir, s3_bucket='osqual-frameworks-artifacts'):

--- a/coreos/1800.7.0/aws/DCOS-1.10.8/docker-18.03.1/dcos_images.yaml
+++ b/coreos/1800.7.0/aws/DCOS-1.10.8/docker-18.03.1/dcos_images.yaml
@@ -1,0 +1,15 @@
+ap-northeast-1: ami-03b53d661dd45796e
+ap-northeast-2: ami-0187bc5f1e434a006
+ap-south-1: ami-0c9018d8a9ed3fd9f
+ap-southeast-1: ami-0c668cf85bb01ec42
+ap-southeast-2: ami-0a02fbfecd172a2e3
+ca-central-1: ami-09c1d5bb525e392a7
+eu-central-1: ami-0bbcd0b246e5fdee1
+eu-west-1: ami-05025acfe6cabc747
+eu-west-2: ami-0888a39b29470d221
+eu-west-3: ami-086eea6e5fafd8afe
+sa-east-1: ami-089fabbce79dde596
+us-east-1: ami-014364fcb93ff5584
+us-east-2: ami-08e5a3bb62f948059
+us-west-1: ami-08fd790b715170a43
+us-west-2: ami-0a277b9eed73df69b

--- a/coreos/1800.7.0/aws/DCOS-1.10.8/docker-18.03.1/desired_cluster_profile.tfvars
+++ b/coreos/1800.7.0/aws/DCOS-1.10.8/docker-18.03.1/desired_cluster_profile.tfvars
@@ -1,0 +1,16 @@
+os = "coreos"
+user = "core"
+aws_region = "us-west-2"
+
+aws_bootstrap_instance_type = "m3.large"
+aws_master_instance_type = "m4.xlarge"
+aws_agent_instance_type = "m4.xlarge"
+aws_public_agent_instance_type = "m4.xlarge"
+
+ssh_key_name = "dcos-images"
+# Inbound Master Access
+admin_cidr = "0.0.0.0/0"
+
+num_of_masters = "1"
+num_of_private_agents = "5"
+num_of_public_agents = "1"

--- a/coreos/1800.7.0/aws/DCOS-1.10.8/docker-18.03.1/desired_cluster_profile.tfvars
+++ b/coreos/1800.7.0/aws/DCOS-1.10.8/docker-18.03.1/desired_cluster_profile.tfvars
@@ -14,3 +14,5 @@ admin_cidr = "0.0.0.0/0"
 num_of_masters = "1"
 num_of_private_agents = "5"
 num_of_public_agents = "1"
+
+custom_dcos_download_path = "https://downloads.dcos.io/dcos/stable/1.10.8/dcos_generate_config.sh"

--- a/coreos/1800.7.0/aws/DCOS-1.10.8/docker-18.03.1/install_dcos_prerequisites.sh
+++ b/coreos/1800.7.0/aws/DCOS-1.10.8/docker-18.03.1/install_dcos_prerequisites.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+sudo systemctl disable locksmithd
+sudo systemctl stop locksmithd
+sudo systemctl restart docker # Restarting docker to ensure its ready. Seems like its not during first usage.

--- a/coreos/1800.7.0/aws/DCOS-1.10.8/docker-18.03.1/packer.json
+++ b/coreos/1800.7.0/aws/DCOS-1.10.8/docker-18.03.1/packer.json
@@ -14,7 +14,7 @@
       "secret_key": "{{user `aws_secret_key`}}",
       "ssh_username": "core",
       "ami_name": "dcos-ami-{{timestamp}}",
-      "ami_description": "coreos/1800.7.0/aws/DCOS-1.11.6/docker-18.03.1",
+      "ami_description": "coreos/1800.7.0/aws/DCOS-1.10.8/docker-18.03.1",
       "ami_regions": [
         "ap-northeast-1",
         "ap-northeast-2",

--- a/coreos/1800.7.0/aws/DCOS-1.10.8/docker-18.03.1/packer.json
+++ b/coreos/1800.7.0/aws/DCOS-1.10.8/docker-18.03.1/packer.json
@@ -1,0 +1,56 @@
+{
+  "variables": {
+    "aws_access_key": "{{env `AWS_ACCESS_KEY_ID`}}",
+    "aws_secret_key": "{{env `AWS_SECRET_ACCESS_KEY`}}",
+    "region":         "us-west-2"
+  },
+  "builders": [
+    {
+      "type": "amazon-ebs",
+      "instance_type": "m4.xlarge",
+      "source_ami": "ami-09e088627f26fd7ec",
+      "region": "us-west-2",
+      "access_key": "{{user `aws_access_key`}}",
+      "secret_key": "{{user `aws_secret_key`}}",
+      "ssh_username": "core",
+      "ami_name": "dcos-ami-{{timestamp}}",
+      "ami_description": "coreos/1800.7.0/aws/DCOS-1.11.6/docker-18.03.1",
+      "ami_regions": [
+        "ap-northeast-1",
+        "ap-northeast-2",
+        "ap-south-1",
+        "ap-southeast-1",
+        "ap-southeast-2",
+        "ca-central-1",
+        "eu-central-1",
+        "eu-west-1",
+        "eu-west-2",
+        "eu-west-3",
+        "sa-east-1",
+        "us-east-1",
+        "us-east-2",
+        "us-west-1",
+        "us-west-2"
+      ],
+      "ami_groups": "all",
+      "ebs_optimized": true,
+      "ena_support": true,
+      "sriov_support": true
+    }
+  ],
+  "provisioners": [
+    {
+      "type": "shell",
+      "script": "./install_dcos_prerequisites.sh"
+    }
+  ],
+  "post-processors": [
+    [
+      {
+        "output": "packer_build_history.json",
+        "strip_path": true,
+        "type": "manifest"
+      }
+    ]
+  ]
+}

--- a/coreos/1800.7.0/aws/DCOS-1.10.8/docker-18.03.1/packer_build_history.json
+++ b/coreos/1800.7.0/aws/DCOS-1.10.8/docker-18.03.1/packer_build_history.json
@@ -1,0 +1,13 @@
+{
+  "builds": [
+    {
+      "name": "amazon-ebs",
+      "builder_type": "amazon-ebs",
+      "build_time": 1537988227,
+      "files": null,
+      "artifact_id": "ap-northeast-1:ami-03b53d661dd45796e,ap-northeast-2:ami-0187bc5f1e434a006,ap-south-1:ami-0c9018d8a9ed3fd9f,ap-southeast-1:ami-0c668cf85bb01ec42,ap-southeast-2:ami-0a02fbfecd172a2e3,ca-central-1:ami-09c1d5bb525e392a7,eu-central-1:ami-0bbcd0b246e5fdee1,eu-west-1:ami-05025acfe6cabc747,eu-west-2:ami-0888a39b29470d221,eu-west-3:ami-086eea6e5fafd8afe,sa-east-1:ami-089fabbce79dde596,us-east-1:ami-014364fcb93ff5584,us-east-2:ami-08e5a3bb62f948059,us-west-1:ami-08fd790b715170a43,us-west-2:ami-0a277b9eed73df69b",
+      "packer_run_uuid": "ccc443f7-0e30-621e-db69-226a2b95107a"
+    }
+  ],
+  "last_run_uuid": "ccc443f7-0e30-621e-db69-226a2b95107a"
+}

--- a/coreos/1800.7.0/aws/DCOS-1.10.8/docker-18.03.1/publish_and_test_config.yaml
+++ b/coreos/1800.7.0/aws/DCOS-1.10.8/docker-18.03.1/publish_and_test_config.yaml
@@ -1,0 +1,4 @@
+# options: packer_build, dcos_installation, integration_tests, never. Default is dcos_installation. For more details, see README
+publish_dcos_images_after: dcos_installation
+run_framework_tests: true
+run_integration_tests: true

--- a/coreos/1800.7.0/aws/DCOS-1.10.8/docker-18.03.1/publish_and_test_config.yaml
+++ b/coreos/1800.7.0/aws/DCOS-1.10.8/docker-18.03.1/publish_and_test_config.yaml
@@ -1,4 +1,4 @@
 # options: packer_build, dcos_installation, integration_tests, never. Default is dcos_installation. For more details, see README
-publish_dcos_images_after: dcos_installation
-run_framework_tests: true
-run_integration_tests: true
+publish_dcos_images_after: never
+run_framework_tests: false
+run_integration_tests: false

--- a/coreos/1800.7.0/aws/DCOS-1.10.8/docker-18.03.1/setup.sh
+++ b/coreos/1800.7.0/aws/DCOS-1.10.8/docker-18.03.1/setup.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+sudo systemctl disable locksmithd
+sudo systemctl stop locksmithd
+sudo systemctl mask locksmithd
+
+sudo systemctl disable update-engine # Disabling automatic updates.
+sudo systemctl stop update-engine
+sudo systemctl mask update-engine
+sudo systemctl restart docker # Restarting docker to ensure its ready. Seems like its not during first usage

--- a/coreos/1800.7.0/aws/base_images.json
+++ b/coreos/1800.7.0/aws/base_images.json
@@ -1,0 +1,20 @@
+{
+  "us-gov-west-1": "ami-1fc6597e",
+  "ap-northeast-2": "ami-0ee8ead7a56410bf9",
+  "sa-east-1": "ami-04a7ebb302d65e89c",
+  "eu-west-2": "ami-00985bd8806d05c41",
+  "us-west-2": "ami-09e088627f26fd7ec",
+  "eu-central-1": "ami-03ee0a0310474a00e",
+  "us-east-1": "ami-00cc4337762ba4a52",
+  "us-east-2": "ami-0bb4f3b6a361ca725",
+  "ca-central-1": "ami-3423ae50",
+  "ap-southeast-1": "ami-019daec4f68b5010b",
+  "ap-northeast-1": "ami-0c381f2f14ecc78f7",
+  "ap-south-1": "ami-07a2cf92cba794c86",
+  "eu-west-3": "ami-004dbd1511bc95349",
+  "cn-north-1": "ami-0d5ec5d735beb907e",
+  "cn-northwest-1": "ami-02a5768104b4e8d4c",
+  "eu-west-1": "ami-02e92935e00c60cf0",
+  "ap-southeast-2": "ami-054c3b6bd4def7efd",
+  "us-west-1": "ami-03a95800c211ab99d"
+}


### PR DESCRIPTION
JIRA: https://jira.mesosphere.com/browse/DCOS-42005
Results: `9 failed, 100 passed, 5 skipped, 1 pytest-warnings in 11104.32 seconds`

Closing this PR as the networking fix for this is going into DC/OS 1.10.10