### PR TITLE
Removing _write_dcos_version_to_cluster_profile method.

### DIFF
--- a/build_test_publish_images.py
+++ b/build_test_publish_images.py
@@ -354,18 +354,6 @@ def packer_validate_and_build(build_dir, dry_run, publish_step):
             publish_dcos_images(build_dir)
 
 
-def _write_dcos_version_to_cluster_profile(build_dir, tf_dir):
-    """ Writing the dcos_version and custom_dcos_download_path cluster profile parameters
-    to desired_cluster_profile.tfvars.
-    """
-    dcos_version = build_dir.split('/')[3][5:]
-    url = "https://downloads.dcos.io/dcos/{}/dcos_generate_config.sh"
-    dcos_download_url = url.format('testing/' + dcos_version) if dcos_version == 'master' else url.format(
-        'stable/' + dcos_version)
-    with open(os.path.join(tf_dir, 'desired_cluster_profile.tfvars'), "a") as f:
-        f.write('\ncustom_dcos_download_path = "{}"\n'.format(dcos_download_url))
-
-
 def _get_agent_ips(tf_dir):
     """ Retrieving both the public and private IPs of agents.
     """
@@ -388,8 +376,6 @@ def setup_terraform(build_dir, tf_dir):
     _terraform_add_os(build_dir, tf_dir, platform, vars_string, ami, os_name)
 
     shutil.copyfile(cluster_profile, os.path.join(tf_dir, CLUSTER_PROFILE_TFVARS))
-
-    _write_dcos_version_to_cluster_profile(build_dir, tf_dir)
 
     _add_private_ips_to_terraform(tf_dir)
 

--- a/centos/7.4/aws/DCOS-1.11.3/docker-1.13.1/selinux_disabled/desired_cluster_profile.tfvars
+++ b/centos/7.4/aws/DCOS-1.11.3/docker-1.13.1/selinux_disabled/desired_cluster_profile.tfvars
@@ -14,3 +14,5 @@ admin_cidr = "0.0.0.0/0"
 num_of_masters = "1"
 num_of_private_agents = "5"
 num_of_public_agents = "1"
+
+custom_dcos_download_path = "https://downloads.dcos.io/dcos/stable/1.11.3/dcos_generate_config.sh"

--- a/coreos/1235.12.0/aws/DCOS-1.11.3/docker-1.12.6/desired_cluster_profile.tfvars
+++ b/coreos/1235.12.0/aws/DCOS-1.11.3/docker-1.12.6/desired_cluster_profile.tfvars
@@ -14,3 +14,5 @@ admin_cidr = "0.0.0.0/0"
 num_of_masters = "1"
 num_of_private_agents = "5"
 num_of_public_agents = "1"
+
+custom_dcos_download_path = "https://downloads.dcos.io/dcos/stable/1.11.3/dcos_generate_config.sh"

--- a/coreos/1688.4.0/aws/DCOS-1.11.3/docker-17.12.1/desired_cluster_profile.tfvars
+++ b/coreos/1688.4.0/aws/DCOS-1.11.3/docker-17.12.1/desired_cluster_profile.tfvars
@@ -14,3 +14,5 @@ admin_cidr = "0.0.0.0/0"
 num_of_masters = "1"
 num_of_private_agents = "5"
 num_of_public_agents = "1"
+
+custom_dcos_download_path = "https://downloads.dcos.io/dcos/stable/1.11.3/dcos_generate_config.sh"

--- a/coreos/1745.7.0/aws/DCOS-1.11.3/docker-18.03.1/desired_cluster_profile.tfvars
+++ b/coreos/1745.7.0/aws/DCOS-1.11.3/docker-18.03.1/desired_cluster_profile.tfvars
@@ -14,3 +14,5 @@ admin_cidr = "0.0.0.0/0"
 num_of_masters = "1"
 num_of_private_agents = "5"
 num_of_public_agents = "1"
+
+custom_dcos_download_path = "https://downloads.dcos.io/dcos/stable/1.11.3/dcos_generate_config.sh"

--- a/coreos/835.13.0/aws/DCOS-1.11.3/docker-1.8.3/desired_cluster_profile.tfvars
+++ b/coreos/835.13.0/aws/DCOS-1.11.3/docker-1.8.3/desired_cluster_profile.tfvars
@@ -14,3 +14,5 @@ admin_cidr = "0.0.0.0/0"
 num_of_masters = "1"
 num_of_private_agents = "5"
 num_of_public_agents = "1"
+
+custom_dcos_download_path = "https://downloads.dcos.io/dcos/stable/1.11.3/dcos_generate_config.sh"

--- a/oracle-linux/7.4/aws/DCOS-1.11.3/docker-1.13.1/desired_cluster_profile.tfvars
+++ b/oracle-linux/7.4/aws/DCOS-1.11.3/docker-1.13.1/desired_cluster_profile.tfvars
@@ -14,3 +14,5 @@ admin_cidr = "0.0.0.0/0"
 num_of_masters = "1"
 num_of_private_agents = "5"
 num_of_public_agents = "1"
+
+custom_dcos_download_path = "https://downloads.dcos.io/dcos/stable/1.11.3/dcos_generate_config.sh"


### PR DESCRIPTION
From now on, the `custom_dcos_download_path` will be supplied by the PR creator in the cluster profile.