### PR TITLE
[BLOCKED] Qualifying DC/OS 1.10.8 against CoreOS 1855.5.0

### DIFF
--- a/coreos/1855.5.0/aws/DCOS-1.10.8/docker-18.06.1/dcos_images.yaml
+++ b/coreos/1855.5.0/aws/DCOS-1.10.8/docker-18.06.1/dcos_images.yaml
@@ -1,0 +1,15 @@
+ap-northeast-1: ami-0a8c6be5f87b35dd4
+ap-northeast-2: ami-0cac5781f008b2bda
+ap-south-1: ami-0cd820071bc8b5305
+ap-southeast-1: ami-00aa99ecc25144574
+ap-southeast-2: ami-008d71c75e5ae947c
+ca-central-1: ami-07d53410c0f2b0132
+eu-central-1: ami-09699c9a5df9e662b
+eu-west-1: ami-07c86c6e70759b682
+eu-west-2: ami-074e993e6c24f801b
+eu-west-3: ami-09cb56d44bcbdde4b
+sa-east-1: ami-01b155f0246dad1a8
+us-east-1: ami-0bb5afc82c391abb7
+us-east-2: ami-068b76746d50afb12
+us-west-1: ami-07d8f0cf1498b72f4
+us-west-2: ami-0884a563b7da04715

--- a/coreos/1855.5.0/aws/DCOS-1.10.8/docker-18.06.1/desired_cluster_profile.tfvars
+++ b/coreos/1855.5.0/aws/DCOS-1.10.8/docker-18.06.1/desired_cluster_profile.tfvars
@@ -1,0 +1,18 @@
+os = "coreos"
+user = "core"
+aws_region = "us-west-2"
+
+aws_bootstrap_instance_type = "m3.large"
+aws_master_instance_type = "m4.xlarge"
+aws_agent_instance_type = "m4.xlarge"
+aws_public_agent_instance_type = "m4.xlarge"
+
+ssh_key_name = "dcos-images"
+# Inbound Master Access
+admin_cidr = "0.0.0.0/0"
+
+num_of_masters = "1"
+num_of_private_agents = "5"
+num_of_public_agents = "1"
+
+custom_dcos_download_path = "https://downloads.dcos.io/dcos/stable/1.10.8/dcos_generate_config.sh"

--- a/coreos/1855.5.0/aws/DCOS-1.10.8/docker-18.06.1/install_dcos_prerequisites.sh
+++ b/coreos/1855.5.0/aws/DCOS-1.10.8/docker-18.06.1/install_dcos_prerequisites.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+sudo systemctl disable locksmithd
+sudo systemctl stop locksmithd
+sudo systemctl restart docker # Restarting docker to ensure its ready. Seems like its not during first usage.

--- a/coreos/1855.5.0/aws/DCOS-1.10.8/docker-18.06.1/packer.json
+++ b/coreos/1855.5.0/aws/DCOS-1.10.8/docker-18.06.1/packer.json
@@ -1,0 +1,56 @@
+{
+  "variables": {
+    "aws_access_key": "{{env `AWS_ACCESS_KEY_ID`}}",
+    "aws_secret_key": "{{env `AWS_SECRET_ACCESS_KEY`}}",
+    "region":         "us-west-2"
+  },
+  "builders": [
+    {
+      "type": "amazon-ebs",
+      "instance_type": "m4.xlarge",
+      "source_ami": "ami-05507591f0fcb2b75",
+      "region": "us-west-2",
+      "access_key": "{{user `aws_access_key`}}",
+      "secret_key": "{{user `aws_secret_key`}}",
+      "ssh_username": "core",
+      "ami_name": "dcos-ami-{{timestamp}}",
+      "ami_description": "coreos/1855.5.0/aws/DCOS-1.12.0/docker-18.06.1",
+      "ami_regions": [
+        "ap-northeast-1",
+        "ap-northeast-2",
+        "ap-south-1",
+        "ap-southeast-1",
+        "ap-southeast-2",
+        "ca-central-1",
+        "eu-central-1",
+        "eu-west-1",
+        "eu-west-2",
+        "eu-west-3",
+        "sa-east-1",
+        "us-east-1",
+        "us-east-2",
+        "us-west-1",
+        "us-west-2"
+      ],
+      "ami_groups": "all",
+      "ebs_optimized": true,
+      "ena_support": true,
+      "sriov_support": true
+    }
+  ],
+  "provisioners": [
+    {
+      "type": "shell",
+      "script": "./install_dcos_prerequisites.sh"
+    }
+  ],
+  "post-processors": [
+    [
+      {
+        "output": "packer_build_history.json",
+        "strip_path": true,
+        "type": "manifest"
+      }
+    ]
+  ]
+}

--- a/coreos/1855.5.0/aws/DCOS-1.10.8/docker-18.06.1/packer.json
+++ b/coreos/1855.5.0/aws/DCOS-1.10.8/docker-18.06.1/packer.json
@@ -14,7 +14,7 @@
       "secret_key": "{{user `aws_secret_key`}}",
       "ssh_username": "core",
       "ami_name": "dcos-ami-{{timestamp}}",
-      "ami_description": "coreos/1855.5.0/aws/DCOS-1.12.0/docker-18.06.1",
+      "ami_description": "coreos/1855.5.0/aws/DCOS-1.10.8/docker-18.06.1",
       "ami_regions": [
         "ap-northeast-1",
         "ap-northeast-2",

--- a/coreos/1855.5.0/aws/DCOS-1.10.8/docker-18.06.1/packer_build_history.json
+++ b/coreos/1855.5.0/aws/DCOS-1.10.8/docker-18.06.1/packer_build_history.json
@@ -1,0 +1,13 @@
+{
+  "builds": [
+    {
+      "name": "amazon-ebs",
+      "builder_type": "amazon-ebs",
+      "build_time": 1541631083,
+      "files": null,
+      "artifact_id": "ap-northeast-1:ami-0a8c6be5f87b35dd4,ap-northeast-2:ami-0cac5781f008b2bda,ap-south-1:ami-0cd820071bc8b5305,ap-southeast-1:ami-00aa99ecc25144574,ap-southeast-2:ami-008d71c75e5ae947c,ca-central-1:ami-07d53410c0f2b0132,eu-central-1:ami-09699c9a5df9e662b,eu-west-1:ami-07c86c6e70759b682,eu-west-2:ami-074e993e6c24f801b,eu-west-3:ami-09cb56d44bcbdde4b,sa-east-1:ami-01b155f0246dad1a8,us-east-1:ami-0bb5afc82c391abb7,us-east-2:ami-068b76746d50afb12,us-west-1:ami-07d8f0cf1498b72f4,us-west-2:ami-0884a563b7da04715",
+      "packer_run_uuid": "c4930de5-63bd-0a9f-ec68-122f3d588f93"
+    }
+  ],
+  "last_run_uuid": "c4930de5-63bd-0a9f-ec68-122f3d588f93"
+}

--- a/coreos/1855.5.0/aws/DCOS-1.10.8/docker-18.06.1/publish_and_test_config.yaml
+++ b/coreos/1855.5.0/aws/DCOS-1.10.8/docker-18.06.1/publish_and_test_config.yaml
@@ -1,0 +1,4 @@
+# options: packer_build, dcos_installation, integration_tests, never. Default is dcos_installation. For more details, see README
+publish_dcos_images_after: integration_tests
+run_framework_tests: true
+run_integration_tests: true

--- a/coreos/1855.5.0/aws/DCOS-1.10.8/docker-18.06.1/setup.sh
+++ b/coreos/1855.5.0/aws/DCOS-1.10.8/docker-18.06.1/setup.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+sudo systemctl disable locksmithd
+sudo systemctl stop locksmithd
+sudo systemctl mask locksmithd
+
+sudo systemctl disable update-engine # Disabling automatic updates.
+sudo systemctl stop update-engine
+sudo systemctl mask update-engine
+sudo systemctl restart docker # Restarting docker to ensure its ready. Seems like its not during first usage

--- a/coreos/1855.5.0/aws/base_images.json
+++ b/coreos/1855.5.0/aws/base_images.json
@@ -1,0 +1,20 @@
+{
+  "ap-northeast-1": "ami-0b0fc6983c9be8f9e",
+  "ap-northeast-2": "ami-09143ca0b3755b428",
+  "ap-south-1": "ami-03eba32062e159d3c",
+  "ap-southeast-1": "ami-0d0079786d2ee66ae",
+  "ap-southeast-2": "ami-029d8ef1a02553d2d",
+  "ca-central-1": "ami-09985fec721ff6f89",
+  "cn-north-1": "ami-0211d60ca1aaa3c7d",
+  "cn-northwest-1": "ami-0deaa8ada18aec612",
+  "eu-central-1": "ami-0e6601a88a9753474",
+  "eu-west-1": "ami-06c40d1010f762df9",
+  "eu-west-2": "ami-0f55bf46b69b768bd",
+  "eu-west-3": "ami-0a2c50627b8b434df",
+  "sa-east-1": "ami-0c188431919e8b2f1",
+  "us-east-1": "ami-0f74e41ea6c13f74b",
+  "us-east-2": "ami-0ba531e8a11f8965d",
+  "us-gov-west-1": "ami-9d58c2fc",
+  "us-west-1": "ami-08b3af8ec59b84ef9",
+  "us-west-2": "ami-05507591f0fcb2b75"
+}


### PR DESCRIPTION
`Results: 9 failed, 100 passed, 5 skipped, 1 pytest-warnings in 11228.55 seconds`

Closing this PR as the networking fix for this is going into DC/OS 1.10.10