### PR TITLE
Qualifying DC/OS 1.12.0 on CoreOS 1911.3.0

### DIFF
--- a/coreos/1911.3.0/aws/DCOS-1.12.0/docker-18.06.1/dcos_images.yaml
+++ b/coreos/1911.3.0/aws/DCOS-1.12.0/docker-18.06.1/dcos_images.yaml
@@ -1,0 +1,15 @@
+ap-northeast-1: ami-0bf49079717edd064
+ap-northeast-2: ami-0ac7073931227f1c1
+ap-south-1: ami-017d89a74d9e4220e
+ap-southeast-1: ami-0a530f912575cca87
+ap-southeast-2: ami-00acc70d639ff7def
+ca-central-1: ami-0f3226d1a8704daba
+eu-central-1: ami-0465ab0c455742414
+eu-west-1: ami-058f4cd5b147fe13c
+eu-west-2: ami-08dd2fd0b1de83ea3
+eu-west-3: ami-077e1d01e90eccd7d
+sa-east-1: ami-0dff92f5bfbd1c1b5
+us-east-1: ami-0c134f0fce5e40ca3
+us-east-2: ami-00143bf69ad45f1fa
+us-west-1: ami-02b8e3b6ad9f530fe
+us-west-2: ami-0c913f9b2797bd3e4

--- a/coreos/1911.3.0/aws/DCOS-1.12.0/docker-18.06.1/desired_cluster_profile.tfvars
+++ b/coreos/1911.3.0/aws/DCOS-1.12.0/docker-18.06.1/desired_cluster_profile.tfvars
@@ -1,0 +1,18 @@
+os = "coreos"
+user = "core"
+aws_region = "us-west-2"
+
+aws_bootstrap_instance_type = "m3.large"
+aws_master_instance_type = "m4.xlarge"
+aws_agent_instance_type = "m4.xlarge"
+aws_public_agent_instance_type = "m4.xlarge"
+
+ssh_key_name = "dcos-images"
+# Inbound Master Access
+admin_cidr = "0.0.0.0/0"
+
+num_of_masters = "1"
+num_of_private_agents = "5"
+num_of_public_agents = "1"
+
+custom_dcos_download_path = "https://downloads.dcos.io/dcos/stable/1.12.0/dcos_generate_config.sh"

--- a/coreos/1911.3.0/aws/DCOS-1.12.0/docker-18.06.1/install_dcos_prerequisites.sh
+++ b/coreos/1911.3.0/aws/DCOS-1.12.0/docker-18.06.1/install_dcos_prerequisites.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+sudo systemctl disable locksmithd
+sudo systemctl stop locksmithd
+sudo systemctl restart docker # Restarting docker to ensure its ready. Seems like its not during first usage.

--- a/coreos/1911.3.0/aws/DCOS-1.12.0/docker-18.06.1/packer.json
+++ b/coreos/1911.3.0/aws/DCOS-1.12.0/docker-18.06.1/packer.json
@@ -1,0 +1,56 @@
+{
+  "variables": {
+    "aws_access_key": "{{env `AWS_ACCESS_KEY_ID`}}",
+    "aws_secret_key": "{{env `AWS_SECRET_ACCESS_KEY`}}",
+    "region":         "us-west-2"
+  },
+  "builders": [
+    {
+      "type": "amazon-ebs",
+      "instance_type": "m4.xlarge",
+      "source_ami": "ami-02dea79d6a7f53d15",
+      "region": "us-west-2",
+      "access_key": "{{user `aws_access_key`}}",
+      "secret_key": "{{user `aws_secret_key`}}",
+      "ssh_username": "core",
+      "ami_name": "dcos-ami-{{timestamp}}",
+      "ami_description": "coreos/1855.4.0/aws/DCOS-1.12.0-rc3/docker-18.06.1",
+      "ami_regions": [
+        "ap-northeast-1",
+        "ap-northeast-2",
+        "ap-south-1",
+        "ap-southeast-1",
+        "ap-southeast-2",
+        "ca-central-1",
+        "eu-central-1",
+        "eu-west-1",
+        "eu-west-2",
+        "eu-west-3",
+        "sa-east-1",
+        "us-east-1",
+        "us-east-2",
+        "us-west-1",
+        "us-west-2"
+      ],
+      "ami_groups": "all",
+      "ebs_optimized": true,
+      "ena_support": true,
+      "sriov_support": true
+    }
+  ],
+  "provisioners": [
+    {
+      "type": "shell",
+      "script": "./install_dcos_prerequisites.sh"
+    }
+  ],
+  "post-processors": [
+    [
+      {
+        "output": "packer_build_history.json",
+        "strip_path": true,
+        "type": "manifest"
+      }
+    ]
+  ]
+}

--- a/coreos/1911.3.0/aws/DCOS-1.12.0/docker-18.06.1/packer.json
+++ b/coreos/1911.3.0/aws/DCOS-1.12.0/docker-18.06.1/packer.json
@@ -8,13 +8,13 @@
     {
       "type": "amazon-ebs",
       "instance_type": "m4.xlarge",
-      "source_ami": "ami-02dea79d6a7f53d15",
+      "source_ami": "ami-0aee4947be233f88c",
       "region": "us-west-2",
       "access_key": "{{user `aws_access_key`}}",
       "secret_key": "{{user `aws_secret_key`}}",
       "ssh_username": "core",
       "ami_name": "dcos-ami-{{timestamp}}",
-      "ami_description": "coreos/1855.4.0/aws/DCOS-1.12.0-rc3/docker-18.06.1",
+      "ami_description": "coreos/1911.3.0/aws/DCOS-1.12.0/docker-18.06.1",
       "ami_regions": [
         "ap-northeast-1",
         "ap-northeast-2",

--- a/coreos/1911.3.0/aws/DCOS-1.12.0/docker-18.06.1/packer_build_history.json
+++ b/coreos/1911.3.0/aws/DCOS-1.12.0/docker-18.06.1/packer_build_history.json
@@ -1,0 +1,13 @@
+{
+  "builds": [
+    {
+      "name": "amazon-ebs",
+      "builder_type": "amazon-ebs",
+      "build_time": 1542748130,
+      "files": null,
+      "artifact_id": "ap-northeast-1:ami-0bf49079717edd064,ap-northeast-2:ami-0ac7073931227f1c1,ap-south-1:ami-017d89a74d9e4220e,ap-southeast-1:ami-0a530f912575cca87,ap-southeast-2:ami-00acc70d639ff7def,ca-central-1:ami-0f3226d1a8704daba,eu-central-1:ami-0465ab0c455742414,eu-west-1:ami-058f4cd5b147fe13c,eu-west-2:ami-08dd2fd0b1de83ea3,eu-west-3:ami-077e1d01e90eccd7d,sa-east-1:ami-0dff92f5bfbd1c1b5,us-east-1:ami-0c134f0fce5e40ca3,us-east-2:ami-00143bf69ad45f1fa,us-west-1:ami-02b8e3b6ad9f530fe,us-west-2:ami-0c913f9b2797bd3e4",
+      "packer_run_uuid": "7ea796e7-822d-2f4b-0b86-a88d2d9cd02e"
+    }
+  ],
+  "last_run_uuid": "7ea796e7-822d-2f4b-0b86-a88d2d9cd02e"
+}

--- a/coreos/1911.3.0/aws/DCOS-1.12.0/docker-18.06.1/publish_and_test_config.yaml
+++ b/coreos/1911.3.0/aws/DCOS-1.12.0/docker-18.06.1/publish_and_test_config.yaml
@@ -1,0 +1,4 @@
+# options: packer_build, dcos_installation, integration_tests, never. Default is dcos_installation. For more details, see README
+publish_dcos_images_after: dcos_installation
+run_framework_tests: false
+run_integration_tests: true

--- a/coreos/1911.3.0/aws/DCOS-1.12.0/docker-18.06.1/setup.sh
+++ b/coreos/1911.3.0/aws/DCOS-1.12.0/docker-18.06.1/setup.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+sudo systemctl disable locksmithd
+sudo systemctl stop locksmithd
+sudo systemctl mask locksmithd
+
+sudo systemctl disable update-engine # Disabling automatic updates.
+sudo systemctl stop update-engine
+sudo systemctl mask update-engine
+sudo systemctl restart docker # Restarting docker to ensure its ready. Seems like its not during first usage

--- a/coreos/1911.3.0/aws/base_images.json
+++ b/coreos/1911.3.0/aws/base_images.json
@@ -1,0 +1,20 @@
+{
+  "ap-northeast-1": "ami-0113626a2260333a1",
+  "ap-northeast-2": "ami-06e6f1d3067f1de22",
+  "ap-south-1": "ami-027a306ae15c48b3a",
+  "ap-southeast-1": "ami-006b1ac0974ddc205",
+  "ap-southeast-2": "ami-06ed1e9afe9c51d42",
+  "ca-central-1": "ami-0181098d6495cf88d",
+  "cn-north-1": "ami-01bd6c15d7a3e9aaa",
+  "cn-northwest-1": "ami-04c22e04ed0182d0f",
+  "eu-central-1": "ami-0da12413bc1e32107",
+  "eu-west-1": "ami-0a9456e274662f3bd",
+  "eu-west-2": "ami-00a945bef5cfc7054",
+  "eu-west-3": "ami-074dbaf11687e8544",
+  "sa-east-1": "ami-04dcc70d03e772417",
+  "us-east-1": "ami-03ed1c12a1dd84320",
+  "us-east-2": "ami-01be41f5c5bfcd6cc",
+  "us-gov-west-1": "ami-a5e580c4",
+  "us-west-1": "ami-0afb60118573e1488",
+  "us-west-2": "ami-0aee4947be233f88c"
+}


### PR DESCRIPTION
Results: `149 passed, 7 skipped, 16987 warnings in 3021.54 seconds`