### PR TITLE
[BLOCKED] Qualifying DC/OS 1.10.9 against CoreOS 1911.3.0

### DIFF
--- a/coreos/1911.3.0/aws/DCOS-1.10.9/docker-18.06.1/dcos_images.yaml
+++ b/coreos/1911.3.0/aws/DCOS-1.10.9/docker-18.06.1/dcos_images.yaml
@@ -1,0 +1,15 @@
+ap-northeast-1: ami-02507361d5c04aa5a
+ap-northeast-2: ami-01e8bd867919b1932
+ap-south-1: ami-06b15479561f7e965
+ap-southeast-1: ami-080cd72e2fd9bd89f
+ap-southeast-2: ami-04bb16c54312aef23
+ca-central-1: ami-00af7ded7b48b411f
+eu-central-1: ami-0ed1bf72387cee769
+eu-west-1: ami-01c3b61a88e8be73e
+eu-west-2: ami-09c11dcb45f4314f4
+eu-west-3: ami-0a4552207261bf122
+sa-east-1: ami-045a08e49ecff073f
+us-east-1: ami-0e2f3c9f401221d7b
+us-east-2: ami-0072afa5f6be157e2
+us-west-1: ami-0f9a23363c518c1f0
+us-west-2: ami-0800da90251d6d36d

--- a/coreos/1911.3.0/aws/DCOS-1.10.9/docker-18.06.1/desired_cluster_profile.tfvars
+++ b/coreos/1911.3.0/aws/DCOS-1.10.9/docker-18.06.1/desired_cluster_profile.tfvars
@@ -1,0 +1,18 @@
+os = "coreos"
+user = "core"
+aws_region = "us-west-2"
+
+aws_bootstrap_instance_type = "m3.large"
+aws_master_instance_type = "m4.xlarge"
+aws_agent_instance_type = "m4.xlarge"
+aws_public_agent_instance_type = "m4.xlarge"
+
+ssh_key_name = "dcos-images"
+# Inbound Master Access
+admin_cidr = "0.0.0.0/0"
+
+num_of_masters = "1"
+num_of_private_agents = "5"
+num_of_public_agents = "1"
+
+custom_dcos_download_path = "https://downloads.dcos.io/dcos/stable/1.10.9/dcos_generate_config.sh"

--- a/coreos/1911.3.0/aws/DCOS-1.10.9/docker-18.06.1/install_dcos_prerequisites.sh
+++ b/coreos/1911.3.0/aws/DCOS-1.10.9/docker-18.06.1/install_dcos_prerequisites.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+sudo systemctl disable locksmithd
+sudo systemctl stop locksmithd
+sudo systemctl restart docker # Restarting docker to ensure its ready. Seems like its not during first usage.

--- a/coreos/1911.3.0/aws/DCOS-1.10.9/docker-18.06.1/packer.json
+++ b/coreos/1911.3.0/aws/DCOS-1.10.9/docker-18.06.1/packer.json
@@ -1,0 +1,56 @@
+{
+  "variables": {
+    "aws_access_key": "{{env `AWS_ACCESS_KEY_ID`}}",
+    "aws_secret_key": "{{env `AWS_SECRET_ACCESS_KEY`}}",
+    "region":         "us-west-2"
+  },
+  "builders": [
+    {
+      "type": "amazon-ebs",
+      "instance_type": "m4.xlarge",
+      "source_ami": "ami-02dea79d6a7f53d15",
+      "region": "us-west-2",
+      "access_key": "{{user `aws_access_key`}}",
+      "secret_key": "{{user `aws_secret_key`}}",
+      "ssh_username": "core",
+      "ami_name": "dcos-ami-{{timestamp}}",
+      "ami_description": "coreos/1855.4.0/aws/DCOS-1.12.0-rc3/docker-18.06.1",
+      "ami_regions": [
+        "ap-northeast-1",
+        "ap-northeast-2",
+        "ap-south-1",
+        "ap-southeast-1",
+        "ap-southeast-2",
+        "ca-central-1",
+        "eu-central-1",
+        "eu-west-1",
+        "eu-west-2",
+        "eu-west-3",
+        "sa-east-1",
+        "us-east-1",
+        "us-east-2",
+        "us-west-1",
+        "us-west-2"
+      ],
+      "ami_groups": "all",
+      "ebs_optimized": true,
+      "ena_support": true,
+      "sriov_support": true
+    }
+  ],
+  "provisioners": [
+    {
+      "type": "shell",
+      "script": "./install_dcos_prerequisites.sh"
+    }
+  ],
+  "post-processors": [
+    [
+      {
+        "output": "packer_build_history.json",
+        "strip_path": true,
+        "type": "manifest"
+      }
+    ]
+  ]
+}

--- a/coreos/1911.3.0/aws/DCOS-1.10.9/docker-18.06.1/packer.json
+++ b/coreos/1911.3.0/aws/DCOS-1.10.9/docker-18.06.1/packer.json
@@ -8,13 +8,13 @@
     {
       "type": "amazon-ebs",
       "instance_type": "m4.xlarge",
-      "source_ami": "ami-02dea79d6a7f53d15",
+      "source_ami": "ami-0aee4947be233f88c",
       "region": "us-west-2",
       "access_key": "{{user `aws_access_key`}}",
       "secret_key": "{{user `aws_secret_key`}}",
       "ssh_username": "core",
       "ami_name": "dcos-ami-{{timestamp}}",
-      "ami_description": "coreos/1855.4.0/aws/DCOS-1.12.0-rc3/docker-18.06.1",
+      "ami_description": "coreos/1911.3.0/aws/DCOS-1.10.9/docker-18.06.1",
       "ami_regions": [
         "ap-northeast-1",
         "ap-northeast-2",

--- a/coreos/1911.3.0/aws/DCOS-1.10.9/docker-18.06.1/packer_build_history.json
+++ b/coreos/1911.3.0/aws/DCOS-1.10.9/docker-18.06.1/packer_build_history.json
@@ -1,0 +1,13 @@
+{
+  "builds": [
+    {
+      "name": "amazon-ebs",
+      "builder_type": "amazon-ebs",
+      "build_time": 1542753111,
+      "files": null,
+      "artifact_id": "ap-northeast-1:ami-02507361d5c04aa5a,ap-northeast-2:ami-01e8bd867919b1932,ap-south-1:ami-06b15479561f7e965,ap-southeast-1:ami-080cd72e2fd9bd89f,ap-southeast-2:ami-04bb16c54312aef23,ca-central-1:ami-00af7ded7b48b411f,eu-central-1:ami-0ed1bf72387cee769,eu-west-1:ami-01c3b61a88e8be73e,eu-west-2:ami-09c11dcb45f4314f4,eu-west-3:ami-0a4552207261bf122,sa-east-1:ami-045a08e49ecff073f,us-east-1:ami-0e2f3c9f401221d7b,us-east-2:ami-0072afa5f6be157e2,us-west-1:ami-0f9a23363c518c1f0,us-west-2:ami-0800da90251d6d36d",
+      "packer_run_uuid": "4bb9bbc1-070e-fd4d-59bf-6125f95a6c98"
+    }
+  ],
+  "last_run_uuid": "4bb9bbc1-070e-fd4d-59bf-6125f95a6c98"
+}

--- a/coreos/1911.3.0/aws/DCOS-1.10.9/docker-18.06.1/publish_and_test_config.yaml
+++ b/coreos/1911.3.0/aws/DCOS-1.10.9/docker-18.06.1/publish_and_test_config.yaml
@@ -1,0 +1,4 @@
+# options: packer_build, dcos_installation, integration_tests, never. Default is dcos_installation. For more details, see README
+publish_dcos_images_after: dcos_installation
+run_framework_tests: false
+run_integration_tests: true

--- a/coreos/1911.3.0/aws/DCOS-1.10.9/docker-18.06.1/setup.sh
+++ b/coreos/1911.3.0/aws/DCOS-1.10.9/docker-18.06.1/setup.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+sudo systemctl disable locksmithd
+sudo systemctl stop locksmithd
+sudo systemctl mask locksmithd
+
+sudo systemctl disable update-engine # Disabling automatic updates.
+sudo systemctl stop update-engine
+sudo systemctl mask update-engine
+sudo systemctl restart docker # Restarting docker to ensure its ready. Seems like its not during first usage

--- a/coreos/1911.3.0/aws/base_images.json
+++ b/coreos/1911.3.0/aws/base_images.json
@@ -1,0 +1,20 @@
+{
+  "ap-northeast-1": "ami-0113626a2260333a1",
+  "ap-northeast-2": "ami-06e6f1d3067f1de22",
+  "ap-south-1": "ami-027a306ae15c48b3a",
+  "ap-southeast-1": "ami-006b1ac0974ddc205",
+  "ap-southeast-2": "ami-06ed1e9afe9c51d42",
+  "ca-central-1": "ami-0181098d6495cf88d",
+  "cn-north-1": "ami-01bd6c15d7a3e9aaa",
+  "cn-northwest-1": "ami-04c22e04ed0182d0f",
+  "eu-central-1": "ami-0da12413bc1e32107",
+  "eu-west-1": "ami-0a9456e274662f3bd",
+  "eu-west-2": "ami-00a945bef5cfc7054",
+  "eu-west-3": "ami-074dbaf11687e8544",
+  "sa-east-1": "ami-04dcc70d03e772417",
+  "us-east-1": "ami-03ed1c12a1dd84320",
+  "us-east-2": "ami-01be41f5c5bfcd6cc",
+  "us-gov-west-1": "ami-a5e580c4",
+  "us-west-1": "ami-0afb60118573e1488",
+  "us-west-2": "ami-0aee4947be233f88c"
+}


### PR DESCRIPTION
Results: `15 failed, 94 passed, 5 skipped, 1 pytest-warnings in 17008.62 seconds`

Closing this PR as the networking fix is aimed for DC/OS 1.10.10. Once that is released, will re-test.