### PR TITLE
[BLOCKED] Qualifying DC/OS 1.12.0 against RHEL 7.6

### DIFF
--- a/rhel/7.6/aws/DCOS-1.12.0/base_images.json
+++ b/rhel/7.6/aws/DCOS-1.12.0/base_images.json
@@ -1,0 +1,3 @@
+{
+  "us-west-2": "ami-036affea69a1101c9"
+}

--- a/rhel/7.6/aws/DCOS-1.12.0/docker-1.13.1.git8633870/configure_dcos_system.sh
+++ b/rhel/7.6/aws/DCOS-1.12.0/docker-1.13.1.git8633870/configure_dcos_system.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+set -o errexit -o nounset -o pipefail
+
+echo ">>> In configure_dcos_system.sh:"
+
+echo ">>> Kernel: $(uname -r)"
+
+# disabled due to packer build error
+# echo ">>> Disabling SELinux"
+# sed -i 's/SELINUX=enforcing/SELINUX=permissive/g' /etc/selinux/config
+# setenforce permissive
+
+echo ">>> Adjusting SSH Daemon Configuration"
+
+sed -i '/^\s*PermitRootLogin /d' /etc/ssh/sshd_config
+echo -e "\nPermitRootLogin without-password" >> /etc/ssh/sshd_config
+
+sed -i '/^\s*UseDNS /d' /etc/ssh/sshd_config
+echo -e "\nUseDNS no" >> /etc/ssh/sshd_config
+
+echo ">>> Set up filesystem mounts"
+mount_pairs=( "/dev/xvde:/var/lib/mesos"
+              "/dev/nvme1n1:/var/lib/mesos"
+              "/dev/xvdf:/var/lib/docker"
+              "/dev/nvme2n1:/var/lib/docker"
+              "/dev/xvdg:/dcos/volume0"
+              "/dev/nvme3n1:/dcos/volume0"
+              "/dev/xvdh:/var/log"
+              "/dev/nvme4n1:/var/log"
+            )
+for mount_pair in ${mount_pairs[@]}; do
+  device=$(echo ${mount_pair} | cut -d':' -f1)
+  mountpoint=$(echo ${mount_pair} | cut -d':' -f2)
+  device_filenamesafe=$(echo ${device} | sed 's/\//-/g')
+
+  cat << EOF > /etc/systemd/system/dcos_vol_setup${device_filenamesafe}.service
+  [Unit]
+  Description=Initial setup of volume mounts
+  DefaultDependencies=no
+  Before=local-fs-pre.target
+
+  [Service]
+  Type=oneshot
+  TimeoutSec=20
+  ExecStart=/usr/local/sbin/dcos_vol_setup.sh ${device} ${mountpoint}
+
+  [Install]
+  WantedBy=local-fs-pre.target
+EOF
+  systemctl enable dcos_vol_setup${device_filenamesafe}
+done
+
+echo ">>> Disable rsyslog"
+systemctl disable rsyslog
+
+echo ">>> Set journald limits"
+mkdir -p /etc/systemd/journald.conf.d/
+echo -e "[Journal]\nSystemMaxUse=15G" > /etc/systemd/journald.conf.d/dcos-el7-ami.conf
+
+echo ">>> Removing tty requirement for sudo"
+sed -i'' -E 's/^(Defaults.*requiretty)/#\1/' /etc/sudoers
+
+echo ">>> Adding group [nogroup]"
+/usr/sbin/groupadd -f nogroup
+
+echo ">>> Cleaning up SSH host keys"
+shred -u /etc/ssh/*_key /etc/ssh/*_key.pub
+
+echo ">>> Cleaning up accounting files"
+rm -f /var/run/utmp
+>/var/log/lastlog
+>/var/log/wtmp
+>/var/log/btmp
+
+echo ">>> Remove temporary files"
+rm -rf /tmp/* /var/tmp/*
+
+echo ">>> Remove ssh client directories"
+rm -rf /home/*/.ssh /root/.ssh
+
+echo ">>> Remove history"
+unset HISTFILE
+rm -rf /home/*/.*history /root/.*history
+
+echo ">>> Update /etc/hosts on boot"
+update_hosts_script=/usr/local/sbin/dcos-update-etc-hosts
+update_hosts_unit=/etc/systemd/system/dcos-update-etc-hosts.service
+
+mkdir -p "$(dirname $update_hosts_script)"
+
+cat << 'EOF' > "$update_hosts_script"
+#!/bin/bash
+export PATH=/opt/mesosphere/bin:/sbin:/bin:/usr/sbin:/usr/bin
+curl="curl -s -f -m 30 --retry 3"
+fqdn=$($curl http://169.254.169.254/latest/meta-data/local-hostname)
+ip=$($curl http://169.254.169.254/latest/meta-data/local-ipv4)
+echo "Adding $fqdn if $ip is not in /etc/hosts"
+grep ^$ip /etc/hosts > /dev/null || echo -e "$ip\t$fqdn ${fqdn%%.*}" >> /etc/hosts
+EOF
+
+chmod +x "${update_hosts_script}"
+
+cat << EOF > "${update_hosts_unit}"
+[Unit]
+Description=Update /etc/hosts with local FQDN if necessary
+After=network.target
+
+[Service]
+Restart=no
+Type=oneshot
+ExecStart=${update_hosts_script}
+
+[Install]
+WantedBy=multi-user.target
+EOF
+systemctl daemon-reload
+systemctl enable $(basename "${update_hosts_unit}")
+
+
+# Make sure we wait until all the data is written to disk, otherwise
+# Packer might quit too early before the large files are deleted
+sync

--- a/rhel/7.6/aws/DCOS-1.12.0/docker-1.13.1.git8633870/dcos_images.yaml
+++ b/rhel/7.6/aws/DCOS-1.12.0/docker-1.13.1.git8633870/dcos_images.yaml
@@ -1,0 +1,15 @@
+ap-northeast-1: ami-0bfe52d6d145c674e
+ap-northeast-2: ami-083a2cab2efa49e1e
+ap-south-1: ami-0015cf4e9d65b9e50
+ap-southeast-1: ami-024ac75903e3114f1
+ap-southeast-2: ami-0a81a425ed8ebf3c9
+ca-central-1: ami-03cbbb9d44d95c25a
+eu-central-1: ami-0e6000758f18fb6be
+eu-west-1: ami-0569e7216584320c6
+eu-west-2: ami-060da074fcce2b43b
+eu-west-3: ami-04ee024c87e40c629
+sa-east-1: ami-0b34096d89569829a
+us-east-1: ami-0da3316c3c6eb42b0
+us-east-2: ami-0ade9a10f50fa2c1a
+us-west-1: ami-074a555b65ca3c76e
+us-west-2: ami-093949a7969be18da

--- a/rhel/7.6/aws/DCOS-1.12.0/docker-1.13.1.git8633870/dcos_vol_setup.sh
+++ b/rhel/7.6/aws/DCOS-1.12.0/docker-1.13.1.git8633870/dcos_vol_setup.sh
@@ -1,0 +1,110 @@
+#!/bin/bash
+set -o errexit -o nounset -o pipefail
+
+# Avoid getting killed due to https://bugs.freedesktop.org/show_bug.cgi?id=84923 if
+# systemd-journald is restarted while we are running.
+trap '' PIPE
+
+export device=${1:-}
+export mount_location=${2:-}
+export label=$(echo ${mount_location:1:12} | sed 's/\//-/g')
+
+function usage {
+cat <<EOUSAGE
+USAGE: $(basename "$0") <device> <mount_location>
+
+ This script will format, and persistently mount the device to the specified
+ location. It is intended to run as an early systemd unit (local-fs-pre.target)
+ on AWS to set up EBS volumes. If a device cant be found for 5 secons, it is simple skipped.
+
+ If <mount_location> is /var/log the script will migrate existing data to the
+ new filesystem.
+
+ It will only execute if <device> doesn't already contain a filesystem.
+
+EXAMPLES:
+
+ $(basename "$0") /dev/xvde /dcos/volume1
+
+EOUSAGE
+}
+
+# Try to be resilient to SIGPIPE, incase anyone restarts journald while we are running.
+function noncritical {
+  set +e; ${*}; set -e
+}
+
+function checked_mount() {
+  local dev="$1"
+  local location="$2"
+  noncritical echo -n "Mounting: $dev to $location"
+  until grep "^$dev" /etc/mtab > /dev/null; do
+    noncritical sleep 1
+    noncritical echo -n .
+    # mount might think the device is already mounted, so accept nonzero exit status
+    mount "$location" || :
+  done
+  noncritical echo
+}
+
+for i in "$@"
+do
+  case "$i" in                                      # Munging globals, beware
+    -h|--help)                noncritical usage     ;;
+    --)                       break                 ;;
+    *)                        # unknown option      ;;
+  esac
+done
+
+function main {
+  if [[ -z "$mount_location" || -z "$device" ]]
+  then
+    noncritical usage
+    exit 1
+  fi
+
+  noncritical echo -n "Waiting for $device to come online"
+  retry=5
+  until test -b "$device"; do
+    noncritical sleep 1; noncritical echo -n .;
+    let retry=retry-1
+    if [ $retry -eq 0 ]; then
+     noncritical exit 0
+    fi
+  done
+  noncritical echo
+  local formated
+  mkfs.xfs -n ftype=1 -L ${label} $device > /dev/null 2>&1 && formated=true || formated=false
+  if [ "$formated" = true ]
+  then
+    noncritical echo "Setting up device mount"
+    mkdir -p "$mount_location"
+    fstab="LABEL=${label} $mount_location xfs defaults 0 2"
+    noncritical echo "Adding entry to fstab: $fstab"
+    echo "$fstab" >> /etc/fstab
+    if [ "$mount_location" = "/var/log" ]; then
+      noncritical echo "Preparing $device by migrating logs from $mount_location"
+      mkdir -p /var/log-prep
+      mount "$device" /var/log-prep
+      mkdir -p /var/log-prep/journal
+      cp -a /var/log/. /var/log-prep/
+      umount /var/log-prep
+      rmdir /var/log-prep
+      rm -rf /var/log
+      mkdir -p /var/log
+      checked_mount "$device" "$mount_location"
+      systemd-tmpfiles --create --prefix /var/log/journal
+      systemctl kill --signal=SIGUSR1 systemd-journald
+    else
+      checked_mount "$device" "$mount_location"
+    fi
+  else
+    noncritical echo "Device $device contains a filesystem: no action taken"
+    noncritical exit 0
+  fi
+}
+
+if [[ ${1:-} ]] && declare -F | cut -d' ' -f3 | fgrep -qx -- "${1:-}"
+then "$@"
+else main "$@"
+fi

--- a/rhel/7.6/aws/DCOS-1.12.0/docker-1.13.1.git8633870/desired_cluster_profile.tfvars
+++ b/rhel/7.6/aws/DCOS-1.12.0/docker-1.13.1.git8633870/desired_cluster_profile.tfvars
@@ -1,0 +1,18 @@
+os = "rhel"
+user = "ec2-user"
+aws_region = "us-west-2"
+
+aws_bootstrap_instance_type = "m3.large"
+aws_master_instance_type = "m4.xlarge"
+aws_agent_instance_type = "m4.xlarge"
+aws_public_agent_instance_type = "m4.xlarge"
+
+ssh_key_name = "dcos-images"
+# Inbound Master Access
+admin_cidr = "0.0.0.0/0"
+
+num_of_masters = "1"
+num_of_private_agents = "5"
+num_of_public_agents = "1"
+
+custom_dcos_download_path = "https://downloads.dcos.io/dcos/stable/1.12.0/dcos_generate_config.sh"

--- a/rhel/7.6/aws/DCOS-1.12.0/docker-1.13.1.git8633870/install_dcos_prerequisites.sh
+++ b/rhel/7.6/aws/DCOS-1.12.0/docker-1.13.1.git8633870/install_dcos_prerequisites.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+sudo setenforce 0 && \
+sudo sed -i --follow-symlinks 's/^SELINUX=.*/SELINUX=disabled/g' /etc/sysconfig/selinux
+sudo tee /etc/yum.repos.d/docker.repo <<-'EOF'
+[dockerrepo]
+name=Docker Repository
+baseurl=https://yum.dockerproject.org/repo/main/centos/7
+enabled=1
+gpgcheck=1
+gpgkey=https://yum.dockerproject.org/gpg
+EOF
+
+sudo mkdir -p /etc/systemd/system/docker.service.d
+sudo tee /etc/systemd/system/docker.service.d/override.conf <<- EOF
+[Service]
+ExecStart=
+ExecStart=/usr/bin/dockerd
+EOF
+
+sudo yum install -y yum-utils \
+    device-mapper-persistent-data \
+    lvm2
+
+sudo yum makecache fast
+
+#Installing RH's fork of docker 1.13.1 through rhui-REGION-rhel-server-extras repository.
+sudo yum install -y docker --enablerepo=rhui-REGION-rhel-server-extras
+sudo ln -s /usr/libexec/docker/docker-runc-current /usr/libexec/docker/docker-runc
+sudo ln -s ../../usr/libexec/docker/docker-proxy-current /usr/bin/docker-proxy
+
+sudo systemctl start docker
+sudo systemctl enable docker
+
+sudo yum install -y wget
+sudo yum install -y git
+sudo yum install -y unzip
+sudo yum install -y curl
+sudo yum install -y xz
+sudo yum install -y ipset
+sudo yum install -y bind-utils
+sudo yum install -y ntp
+sudo systemctl enable ntpd
+sudo systemctl start ntpd
+sudo getent group nogroup || sudo groupadd nogroup
+sudo getent group docker || sudo groupadd docker
+sudo touch /opt/dcos-prereqs.installed

--- a/rhel/7.6/aws/DCOS-1.12.0/docker-1.13.1.git8633870/packer.json
+++ b/rhel/7.6/aws/DCOS-1.12.0/docker-1.13.1.git8633870/packer.json
@@ -14,7 +14,7 @@
       "secret_key": "{{user `aws_secret_key`}}",
       "ssh_username": "ec2-user",
       "ami_name": "dcos-ami-{{timestamp}}",
-      "ami_description": "rhel/7.6/aws/DCOS-1.10.9/docker-1.13.1.git8633870/",
+      "ami_description": "rhel/7.6/aws/DCOS-1.12.0/docker-1.13.1.git8633870",
       "ami_regions": [
         "ap-northeast-1",
         "ap-northeast-2",

--- a/rhel/7.6/aws/DCOS-1.12.0/docker-1.13.1.git8633870/packer.json
+++ b/rhel/7.6/aws/DCOS-1.12.0/docker-1.13.1.git8633870/packer.json
@@ -1,0 +1,129 @@
+{
+  "variables": {
+    "aws_access_key": "{{env `AWS_ACCESS_KEY_ID`}}",
+    "aws_secret_key": "{{env `AWS_SECRET_ACCESS_KEY`}}",
+    "region":         "us-west-2"
+  },
+  "builders": [
+    {
+      "type": "amazon-ebs",
+      "instance_type": "m4.xlarge",
+      "source_ami": "ami-036affea69a1101c9",
+      "region": "us-west-2",
+      "access_key": "{{user `aws_access_key`}}",
+      "secret_key": "{{user `aws_secret_key`}}",
+      "ssh_username": "ec2-user",
+      "ami_name": "dcos-ami-{{timestamp}}",
+      "ami_description": "rhel/7.6/aws/DCOS-1.10.9/docker-1.13.1.git8633870/",
+      "ami_regions": [
+        "ap-northeast-1",
+        "ap-northeast-2",
+        "ap-south-1",
+        "ap-southeast-1",
+        "ap-southeast-2",
+        "ca-central-1",
+        "eu-central-1",
+        "eu-west-1",
+        "eu-west-2",
+        "eu-west-3",
+        "sa-east-1",
+        "us-east-1",
+        "us-east-2",
+        "us-west-1",
+        "us-west-2"
+      ],
+      "ami_groups": "all",
+      "associate_public_ip_address": true,
+      "ebs_optimized": true,
+      "ena_support": true,
+      "sriov_support": true,
+      "ami_block_device_mappings": [
+        {
+          "device_name": "/dev/sde",
+          "volume_type": "gp2",
+          "volume_size": 50,
+          "delete_on_termination": true
+        },
+        {
+          "device_name": "/dev/sdf",
+          "volume_type": "gp2",
+          "volume_size": 100,
+          "delete_on_termination": true
+        },
+        {
+          "device_name": "/dev/sdg",
+          "volume_type": "gp2",
+          "volume_size": 50,
+          "delete_on_termination": true
+        },
+        {
+          "device_name": "/dev/sdh",
+          "volume_type": "gp2",
+          "volume_size": 20,
+          "delete_on_termination": true
+        }
+      ],
+      "launch_block_device_mappings": [
+        {
+          "device_name": "/dev/sde",
+          "volume_type": "gp2",
+          "volume_size": 50,
+          "delete_on_termination": true
+        },
+        {
+          "device_name": "/dev/sdf",
+          "volume_type": "gp2",
+          "volume_size": 100,
+          "delete_on_termination": true
+        },
+        {
+          "device_name": "/dev/sdg",
+          "volume_type": "gp2",
+          "volume_size": 50,
+          "delete_on_termination": true
+        },
+        {
+          "device_name": "/dev/sdh",
+          "volume_type": "gp2",
+          "volume_size": 20,
+          "delete_on_termination": true
+        }
+      ]
+    }
+  ],
+  "provisioners": [
+    {
+    "type": "file",
+    "source": "./dcos_vol_setup.sh",
+    "destination": "/tmp/dcos_vol_setup.sh"
+    },
+    {
+    "type": "file",
+    "source": "./configure_dcos_system.sh",
+    "destination": "/tmp/configure_dcos_system.sh"
+    },
+    {
+    "type": "shell",
+    "inline_shebang": "/bin/bash -e",
+    "inline": [
+    "sudo mv /tmp/dcos_vol_setup.sh /usr/local/sbin/",
+    "sudo chmod 0755 /usr/local/sbin/dcos_vol_setup.sh",
+    "sudo /tmp/configure_dcos_system.sh"]
+    },
+    {
+    "execute_command": "{{ .Vars }} sudo -E -S bash -c \"cat {{ .Path }} > ~/install_dcos_prerequisites.sh && chmod +x ~/install_dcos_prerequisites.sh && (crontab -l 2>/dev/null; echo '@reboot ~/install_dcos_prerequisites.sh') | crontab -\"",
+    "type": "shell",
+    "script": "./install_dcos_prerequisites.sh"
+    }
+
+  ],
+  "post-processors": [
+    [
+      {
+        "output": "packer_build_history.json",
+        "strip_path": true,
+        "type": "manifest"
+      }
+    ]
+  ]
+}

--- a/rhel/7.6/aws/DCOS-1.12.0/docker-1.13.1.git8633870/packer_build_history.json
+++ b/rhel/7.6/aws/DCOS-1.12.0/docker-1.13.1.git8633870/packer_build_history.json
@@ -1,0 +1,13 @@
+{
+  "builds": [
+    {
+      "name": "amazon-ebs",
+      "builder_type": "amazon-ebs",
+      "build_time": 1544901952,
+      "files": null,
+      "artifact_id": "ap-northeast-1:ami-0bfe52d6d145c674e,ap-northeast-2:ami-083a2cab2efa49e1e,ap-south-1:ami-0015cf4e9d65b9e50,ap-southeast-1:ami-024ac75903e3114f1,ap-southeast-2:ami-0a81a425ed8ebf3c9,ca-central-1:ami-03cbbb9d44d95c25a,eu-central-1:ami-0e6000758f18fb6be,eu-west-1:ami-0569e7216584320c6,eu-west-2:ami-060da074fcce2b43b,eu-west-3:ami-04ee024c87e40c629,sa-east-1:ami-0b34096d89569829a,us-east-1:ami-0da3316c3c6eb42b0,us-east-2:ami-0ade9a10f50fa2c1a,us-west-1:ami-074a555b65ca3c76e,us-west-2:ami-093949a7969be18da",
+      "packer_run_uuid": "a2aef8a8-d1ef-22fe-83ec-594bbfb85ab9"
+    }
+  ],
+  "last_run_uuid": "a2aef8a8-d1ef-22fe-83ec-594bbfb85ab9"
+}

--- a/rhel/7.6/aws/DCOS-1.12.0/docker-1.13.1.git8633870/publish_and_test_config.yaml
+++ b/rhel/7.6/aws/DCOS-1.12.0/docker-1.13.1.git8633870/publish_and_test_config.yaml
@@ -1,0 +1,4 @@
+# options: packer_build, dcos_installation, integration_tests, never. Default is dcos_installation. For more details, see README
+publish_dcos_images_after: integration_tests
+run_framework_tests: false
+run_integration_tests: true

--- a/rhel/7.6/aws/DCOS-1.12.0/docker-1.13.1.git8633870/setup.sh
+++ b/rhel/7.6/aws/DCOS-1.12.0/docker-1.13.1.git8633870/setup.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+sudo setenforce 0 && \
+sudo sed -i --follow-symlinks 's/^SELINUX=.*/SELINUX=disabled/g' /etc/sysconfig/selinux
+sudo tee /etc/yum.repos.d/docker.repo <<-'EOF'
+[dockerrepo]
+name=Docker Repository
+baseurl=https://yum.dockerproject.org/repo/main/centos/7
+enabled=1
+gpgcheck=1
+gpgkey=https://yum.dockerproject.org/gpg
+EOF
+
+sudo mkdir -p /etc/systemd/system/docker.service.d
+sudo tee /etc/systemd/system/docker.service.d/override.conf <<- EOF
+[Service]
+ExecStart=
+ExecStart=/usr/bin/dockerd
+EOF
+
+sudo yum install -y yum-utils \
+    device-mapper-persistent-data \
+    lvm2
+
+sudo yum makecache fast
+
+#Installing RH's fork of docker 1.13.1 through rhui-REGION-rhel-server-extras repository.
+sudo yum install -y docker --enablerepo=rhui-REGION-rhel-server-extras
+sudo ln -s /usr/libexec/docker/docker-runc-current /usr/libexec/docker/docker-runc
+sudo ln -s ../../usr/libexec/docker/docker-proxy-current /usr/bin/docker-proxy
+
+sudo systemctl start docker
+sudo systemctl enable docker
+
+sudo yum install -y wget
+sudo yum install -y git
+sudo yum install -y unzip
+sudo yum install -y curl
+sudo yum install -y xz
+sudo yum install -y ipset
+sudo yum install -y bind-utils
+sudo yum install -y ntp
+sudo systemctl enable ntpd
+sudo systemctl start ntpd
+sudo getent group nogroup || sudo groupadd nogroup
+sudo getent group docker || sudo groupadd docker
+sudo touch /opt/dcos-prereqs.installed


### PR DESCRIPTION
`Result: 2 failed, 147 passed, 7 skipped, 17230 warnings in 4178.59 seconds`
Failures: `test_ipv6[False]` & `test_if_overlay_ok`

Both these tests are muted in the dcos=integration tests for 1.12.1, thus we can ignore the failures in 1.12.0: https://jira.mesosphere.com/browse/DCOS-46298