### PR TITLE
Qualifying DCOS 1.12.2 (RunC Vulnerability) against CoreOS 1967.5.0

### DIFF
--- a/coreos/1967.5.0/aws/DCOS-1.12.2/docker-18.06.1/dcos_images.yaml
+++ b/coreos/1967.5.0/aws/DCOS-1.12.2/docker-18.06.1/dcos_images.yaml
@@ -1,0 +1,15 @@
+ap-northeast-1: ami-0b41d50e24ca20908
+ap-northeast-2: ami-010c2364dfc0ec0b2
+ap-south-1: ami-0fd419f833833d3b4
+ap-southeast-1: ami-0a38f74eafd5b1e48
+ap-southeast-2: ami-0ed0a90dcc5d22d13
+ca-central-1: ami-0cf1fad06cae0d055
+eu-central-1: ami-09473173c4f0af18b
+eu-west-1: ami-0ed30bf435868d278
+eu-west-2: ami-0ad2d52a4507ac818
+eu-west-3: ami-0c967ac474e09bfbf
+sa-east-1: ami-04f5d560b9404bd91
+us-east-1: ami-045189c244fa17bca
+us-east-2: ami-0507362b478845b1d
+us-west-1: ami-096a486393d3ed6cd
+us-west-2: ami-0e56e88a74b4dc5c1

--- a/coreos/1967.5.0/aws/DCOS-1.12.2/docker-18.06.1/desired_cluster_profile.tfvars
+++ b/coreos/1967.5.0/aws/DCOS-1.12.2/docker-18.06.1/desired_cluster_profile.tfvars
@@ -1,0 +1,18 @@
+os = "coreos"
+user = "core"
+aws_region = "us-west-2"
+
+aws_bootstrap_instance_type = "m3.large"
+aws_master_instance_type = "m4.xlarge"
+aws_agent_instance_type = "m4.xlarge"
+aws_public_agent_instance_type = "m4.xlarge"
+
+ssh_key_name = "dcos-images"
+# Inbound Master Access
+admin_cidr = "0.0.0.0/0"
+
+num_of_masters = "1"
+num_of_private_agents = "5"
+num_of_public_agents = "1"
+
+custom_dcos_download_path = "https://downloads.dcos.io/dcos/testing/1.12.2/dcos_generate_config.sh"

--- a/coreos/1967.5.0/aws/DCOS-1.12.2/docker-18.06.1/install_dcos_prerequisites.sh
+++ b/coreos/1967.5.0/aws/DCOS-1.12.2/docker-18.06.1/install_dcos_prerequisites.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+sudo systemctl disable locksmithd
+sudo systemctl stop locksmithd
+sudo systemctl restart docker # Restarting docker to ensure its ready. Seems like its not during first usage.

--- a/coreos/1967.5.0/aws/DCOS-1.12.2/docker-18.06.1/packer.json
+++ b/coreos/1967.5.0/aws/DCOS-1.12.2/docker-18.06.1/packer.json
@@ -8,13 +8,13 @@
     {
       "type": "amazon-ebs",
       "instance_type": "m4.xlarge",
-      "source_ami": "ami-0b5fe761216cc15dd",
+      "source_ami": "ami-0ac262621e0cc606d",
       "region": "us-west-2",
       "access_key": "{{user `aws_access_key`}}",
       "secret_key": "{{user `aws_secret_key`}}",
       "ssh_username": "core",
       "ami_name": "dcos-ami-{{timestamp}}",
-      "ami_description": "coreos/1911.5.0/aws/DCOS-1.12.1/docker-18.06.1",
+      "ami_description": "coreos/1967.5.0/aws/DCOS-1.12.2/docker-18.06.1",
       "ami_regions": [
         "ap-northeast-1",
         "ap-northeast-2",

--- a/coreos/1967.5.0/aws/DCOS-1.12.2/docker-18.06.1/packer.json
+++ b/coreos/1967.5.0/aws/DCOS-1.12.2/docker-18.06.1/packer.json
@@ -1,0 +1,56 @@
+{
+  "variables": {
+    "aws_access_key": "{{env `AWS_ACCESS_KEY_ID`}}",
+    "aws_secret_key": "{{env `AWS_SECRET_ACCESS_KEY`}}",
+    "region":         "us-west-2"
+  },
+  "builders": [
+    {
+      "type": "amazon-ebs",
+      "instance_type": "m4.xlarge",
+      "source_ami": "ami-0b5fe761216cc15dd",
+      "region": "us-west-2",
+      "access_key": "{{user `aws_access_key`}}",
+      "secret_key": "{{user `aws_secret_key`}}",
+      "ssh_username": "core",
+      "ami_name": "dcos-ami-{{timestamp}}",
+      "ami_description": "coreos/1911.5.0/aws/DCOS-1.12.1/docker-18.06.1",
+      "ami_regions": [
+        "ap-northeast-1",
+        "ap-northeast-2",
+        "ap-south-1",
+        "ap-southeast-1",
+        "ap-southeast-2",
+        "ca-central-1",
+        "eu-central-1",
+        "eu-west-1",
+        "eu-west-2",
+        "eu-west-3",
+        "sa-east-1",
+        "us-east-1",
+        "us-east-2",
+        "us-west-1",
+        "us-west-2"
+      ],
+      "ami_groups": "all",
+      "ebs_optimized": true,
+      "ena_support": true,
+      "sriov_support": true
+    }
+  ],
+  "provisioners": [
+    {
+      "type": "shell",
+      "script": "./install_dcos_prerequisites.sh"
+    }
+  ],
+  "post-processors": [
+    [
+      {
+        "output": "packer_build_history.json",
+        "strip_path": true,
+        "type": "manifest"
+      }
+    ]
+  ]
+}

--- a/coreos/1967.5.0/aws/DCOS-1.12.2/docker-18.06.1/packer_build_history.json
+++ b/coreos/1967.5.0/aws/DCOS-1.12.2/docker-18.06.1/packer_build_history.json
@@ -1,0 +1,13 @@
+{
+  "builds": [
+    {
+      "name": "amazon-ebs",
+      "builder_type": "amazon-ebs",
+      "build_time": 1550007769,
+      "files": null,
+      "artifact_id": "ap-northeast-1:ami-0b41d50e24ca20908,ap-northeast-2:ami-010c2364dfc0ec0b2,ap-south-1:ami-0fd419f833833d3b4,ap-southeast-1:ami-0a38f74eafd5b1e48,ap-southeast-2:ami-0ed0a90dcc5d22d13,ca-central-1:ami-0cf1fad06cae0d055,eu-central-1:ami-09473173c4f0af18b,eu-west-1:ami-0ed30bf435868d278,eu-west-2:ami-0ad2d52a4507ac818,eu-west-3:ami-0c967ac474e09bfbf,sa-east-1:ami-04f5d560b9404bd91,us-east-1:ami-045189c244fa17bca,us-east-2:ami-0507362b478845b1d,us-west-1:ami-096a486393d3ed6cd,us-west-2:ami-0e56e88a74b4dc5c1",
+      "packer_run_uuid": "7e723d22-5c77-d850-e0ff-243e3de2638b"
+    }
+  ],
+  "last_run_uuid": "7e723d22-5c77-d850-e0ff-243e3de2638b"
+}

--- a/coreos/1967.5.0/aws/DCOS-1.12.2/docker-18.06.1/publish_and_test_config.yaml
+++ b/coreos/1967.5.0/aws/DCOS-1.12.2/docker-18.06.1/publish_and_test_config.yaml
@@ -1,0 +1,25 @@
+# options: packer_build, dcos_installation, integration_tests, never. Default is dcos_installation. For more details, see README
+publish_dcos_images_after: dcos_installation
+run_framework_tests: false
+run_integration_tests: true
+tests_to_run:
+  - test_applications.py
+  - test_auth.py
+  - test_checks.py
+  - test_composition.py
+  - test_dcos_diagnostics.py
+  - test_dcos_log.py
+  - test_endpoints.py
+  - test_helpers.py
+  - test_mesos.py
+  - test_meta.py
+  - test_metrics.py
+  - test_metronome.py
+  - test_misc.py
+  - test_networking.py
+  - test_rexray.py
+  - test_rlimit.py
+  - test_service_discovery.py
+  - test_sysctl.py
+  - test_ucr.py
+  - test_units.py

--- a/coreos/1967.5.0/aws/DCOS-1.12.2/docker-18.06.1/setup.sh
+++ b/coreos/1967.5.0/aws/DCOS-1.12.2/docker-18.06.1/setup.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+sudo systemctl disable locksmithd
+sudo systemctl stop locksmithd
+sudo systemctl mask locksmithd
+
+sudo systemctl disable update-engine # Disabling automatic updates.
+sudo systemctl stop update-engine
+sudo systemctl mask update-engine
+sudo systemctl restart docker # Restarting docker to ensure its ready. Seems like its not during first usage

--- a/coreos/1967.5.0/aws/base_images.json
+++ b/coreos/1967.5.0/aws/base_images.json
@@ -1,0 +1,20 @@
+{
+  "ap-northeast-1": "ami-07821bd0ea86d4511",
+  "ap-northeast-2": "ami-01b5d118690d7c4db",
+  "ap-south-1": "ami-09642e32f99945765",
+  "ap-southeast-1": "ami-07739b17529e8c1d0",
+  "ap-southeast-2": "ami-02d7d488d701a460e",
+  "ca-central-1": "ami-0edacf783a84b0986",
+  "cn-north-1": "ami-0d405143e313ec9cb",
+  "cn-northwest-1": "ami-0eb5198a7b6239a05",
+  "eu-central-1": "ami-0f46c2ed46d8157aa",
+  "eu-west-1": "ami-0628e483315b5d17e",
+  "eu-west-2": "ami-0ded15c0d8a34dad2",
+  "eu-west-3": "ami-0dea870ebbbd767e4",
+  "sa-east-1": "ami-0d28afc45b6f88ba4",
+  "us-east-1": "ami-0c6731558e5ca73f6",
+  "us-east-2": "ami-05df30c25dffa0eaf",
+  "us-gov-west-1": "ami-07630d66",
+  "us-west-1": "ami-0aaec419396da3b37",
+  "us-west-2": "ami-0ac262621e0cc606d"
+}


### PR DESCRIPTION
`Result: 141 passed, 7 skipped, 7 xpassed, 2 warnings in 3380.68 seconds`