### PR TITLE
Qualifying DCOS 1.11.10 (RunC Vulnerability) against CoreOS 1967.6.0

### DIFF
--- a/coreos/1967.6.0/aws/DCOS-1.11.10/docker-18.06.1/dcos_images.yaml
+++ b/coreos/1967.6.0/aws/DCOS-1.11.10/docker-18.06.1/dcos_images.yaml
@@ -1,0 +1,15 @@
+ap-northeast-1: ami-0c7d81e2c7bf9cc1e
+ap-northeast-2: ami-01ea4b818d1db4fcc
+ap-south-1: ami-05b7a8bc809943e03
+ap-southeast-1: ami-066ba509c21dac715
+ap-southeast-2: ami-0cfcb202b0bb3898c
+ca-central-1: ami-09f0d1b63312d1789
+eu-central-1: ami-099410752ea3dcdf0
+eu-west-1: ami-0cbaed2031038494e
+eu-west-2: ami-0b1220ef348389000
+eu-west-3: ami-02dad2bfbb1701385
+sa-east-1: ami-059a87a1b01902a53
+us-east-1: ami-07c4aebe7db6d5801
+us-east-2: ami-018366ae7be337d3b
+us-west-1: ami-097e53255f2bd7497
+us-west-2: ami-0483e10d6dd4c0705

--- a/coreos/1967.6.0/aws/DCOS-1.11.10/docker-18.06.1/desired_cluster_profile.tfvars
+++ b/coreos/1967.6.0/aws/DCOS-1.11.10/docker-18.06.1/desired_cluster_profile.tfvars
@@ -1,0 +1,18 @@
+os = "coreos"
+user = "core"
+aws_region = "us-west-2"
+
+aws_bootstrap_instance_type = "m3.large"
+aws_master_instance_type = "m4.xlarge"
+aws_agent_instance_type = "m4.xlarge"
+aws_public_agent_instance_type = "m4.xlarge"
+
+ssh_key_name = "dcos-images"
+# Inbound Master Access
+admin_cidr = "0.0.0.0/0"
+
+num_of_masters = "1"
+num_of_private_agents = "5"
+num_of_public_agents = "1"
+
+custom_dcos_download_path = "https://downloads.dcos.io/dcos/stable/1.11.10/dcos_generate_config.sh"

--- a/coreos/1967.6.0/aws/DCOS-1.11.10/docker-18.06.1/install_dcos_prerequisites.sh
+++ b/coreos/1967.6.0/aws/DCOS-1.11.10/docker-18.06.1/install_dcos_prerequisites.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+sudo systemctl disable locksmithd
+sudo systemctl stop locksmithd
+sudo systemctl restart docker # Restarting docker to ensure its ready. Seems like its not during first usage.

--- a/coreos/1967.6.0/aws/DCOS-1.11.10/docker-18.06.1/packer.json
+++ b/coreos/1967.6.0/aws/DCOS-1.11.10/docker-18.06.1/packer.json
@@ -8,13 +8,13 @@
     {
       "type": "amazon-ebs",
       "instance_type": "m4.xlarge",
-      "source_ami": "ami-0b5fe761216cc15dd",
+      "source_ami": "ami-0b0f4f5f0c8c1a797",
       "region": "us-west-2",
       "access_key": "{{user `aws_access_key`}}",
       "secret_key": "{{user `aws_secret_key`}}",
       "ssh_username": "core",
       "ami_name": "dcos-ami-{{timestamp}}",
-      "ami_description": "coreos/1911.5.0/aws/DCOS-1.12.1/docker-18.06.1",
+      "ami_description": "coreos/1967.6.0/aws/DCOS-1.11.10/docker-18.06.1",
       "ami_regions": [
         "ap-northeast-1",
         "ap-northeast-2",

--- a/coreos/1967.6.0/aws/DCOS-1.11.10/docker-18.06.1/packer.json
+++ b/coreos/1967.6.0/aws/DCOS-1.11.10/docker-18.06.1/packer.json
@@ -1,0 +1,56 @@
+{
+  "variables": {
+    "aws_access_key": "{{env `AWS_ACCESS_KEY_ID`}}",
+    "aws_secret_key": "{{env `AWS_SECRET_ACCESS_KEY`}}",
+    "region":         "us-west-2"
+  },
+  "builders": [
+    {
+      "type": "amazon-ebs",
+      "instance_type": "m4.xlarge",
+      "source_ami": "ami-0b5fe761216cc15dd",
+      "region": "us-west-2",
+      "access_key": "{{user `aws_access_key`}}",
+      "secret_key": "{{user `aws_secret_key`}}",
+      "ssh_username": "core",
+      "ami_name": "dcos-ami-{{timestamp}}",
+      "ami_description": "coreos/1911.5.0/aws/DCOS-1.12.1/docker-18.06.1",
+      "ami_regions": [
+        "ap-northeast-1",
+        "ap-northeast-2",
+        "ap-south-1",
+        "ap-southeast-1",
+        "ap-southeast-2",
+        "ca-central-1",
+        "eu-central-1",
+        "eu-west-1",
+        "eu-west-2",
+        "eu-west-3",
+        "sa-east-1",
+        "us-east-1",
+        "us-east-2",
+        "us-west-1",
+        "us-west-2"
+      ],
+      "ami_groups": "all",
+      "ebs_optimized": true,
+      "ena_support": true,
+      "sriov_support": true
+    }
+  ],
+  "provisioners": [
+    {
+      "type": "shell",
+      "script": "./install_dcos_prerequisites.sh"
+    }
+  ],
+  "post-processors": [
+    [
+      {
+        "output": "packer_build_history.json",
+        "strip_path": true,
+        "type": "manifest"
+      }
+    ]
+  ]
+}

--- a/coreos/1967.6.0/aws/DCOS-1.11.10/docker-18.06.1/packer_build_history.json
+++ b/coreos/1967.6.0/aws/DCOS-1.11.10/docker-18.06.1/packer_build_history.json
@@ -1,0 +1,13 @@
+{
+  "builds": [
+    {
+      "name": "amazon-ebs",
+      "builder_type": "amazon-ebs",
+      "build_time": 1550093412,
+      "files": null,
+      "artifact_id": "ap-northeast-1:ami-0c7d81e2c7bf9cc1e,ap-northeast-2:ami-01ea4b818d1db4fcc,ap-south-1:ami-05b7a8bc809943e03,ap-southeast-1:ami-066ba509c21dac715,ap-southeast-2:ami-0cfcb202b0bb3898c,ca-central-1:ami-09f0d1b63312d1789,eu-central-1:ami-099410752ea3dcdf0,eu-west-1:ami-0cbaed2031038494e,eu-west-2:ami-0b1220ef348389000,eu-west-3:ami-02dad2bfbb1701385,sa-east-1:ami-059a87a1b01902a53,us-east-1:ami-07c4aebe7db6d5801,us-east-2:ami-018366ae7be337d3b,us-west-1:ami-097e53255f2bd7497,us-west-2:ami-0483e10d6dd4c0705",
+      "packer_run_uuid": "44d36ae2-f1cf-2387-9b65-e2a367eb53f5"
+    }
+  ],
+  "last_run_uuid": "44d36ae2-f1cf-2387-9b65-e2a367eb53f5"
+}

--- a/coreos/1967.6.0/aws/DCOS-1.11.10/docker-18.06.1/publish_and_test_config.yaml
+++ b/coreos/1967.6.0/aws/DCOS-1.11.10/docker-18.06.1/publish_and_test_config.yaml
@@ -1,0 +1,24 @@
+# options: packer_build, dcos_installation, integration_tests, never. Default is dcos_installation. For more details, see README
+publish_dcos_images_after: dcos_installation
+run_framework_tests: false
+run_integration_tests: true
+tests_to_run:
+  - test_applications.py
+  - test_auth.py
+  - test_composition.py
+  - test_dcos_diagnostics.py
+  - test_dcos_log.py
+  - test_endpoints.py
+  - test_helpers.py
+  - test_mesos.py
+  - test_meta.py
+  - test_metrics.py
+  - test_metronome.py
+  - test_misc.py
+  - test_networking.py
+  - test_rexray.py
+  - test_rlimit.py
+  - test_service_discovery.py
+  - test_sysctl.py
+  - test_ucr.py
+  - test_units.py

--- a/coreos/1967.6.0/aws/DCOS-1.11.10/docker-18.06.1/setup.sh
+++ b/coreos/1967.6.0/aws/DCOS-1.11.10/docker-18.06.1/setup.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+sudo systemctl disable locksmithd
+sudo systemctl stop locksmithd
+sudo systemctl mask locksmithd
+
+sudo systemctl disable update-engine # Disabling automatic updates.
+sudo systemctl stop update-engine
+sudo systemctl mask update-engine
+sudo systemctl restart docker # Restarting docker to ensure its ready. Seems like its not during first usage

--- a/coreos/1967.6.0/aws/base_images.json
+++ b/coreos/1967.6.0/aws/base_images.json
@@ -1,0 +1,20 @@
+{
+  "ap-northeast-1": "ami-0674bd656e5bbd940",
+  "ap-northeast-2": "ami-0dedec04918e56116",
+  "ap-south-1": "ami-0bdbad103cc31c037",
+  "ap-southeast-1": "ami-0e11019a200802b43",
+  "ap-southeast-2": "ami-094bde83db4642610",
+  "ca-central-1": "ami-0c119337e0f202885",
+  "cn-north-1": "ami-001e6f29a899df749",
+  "cn-northwest-1": "ami-00a0d2ef649391775",
+  "eu-central-1": "ami-00946a0f23931daac",
+  "eu-west-1": "ami-0cdf1816f4d8d634e",
+  "eu-west-2": "ami-0bf0bc4adb43e8fc7",
+  "eu-west-3": "ami-0a931bb3434fe57f0",
+  "sa-east-1": "ami-0c33cc9b83b72fae6",
+  "us-east-1": "ami-0089347d530e1f3e6",
+  "us-east-2": "ami-0b15c21563ba827f2",
+  "us-gov-west-1": "ami-c45638a5",
+  "us-west-1": "ami-09e198d9d9ef8052b",
+  "us-west-2": "ami-0b0f4f5f0c8c1a797"
+}


### PR DESCRIPTION
`Results: 132 passed, 6 skipped, 4 xpassed, 2 warnings in 2823.11 seconds`