### PR TITLE
Qualifying DC/OS 1.10.11 against CoreOS 2023.4.0

### DIFF
--- a/coreos/2023.4.0/aws/DCOS-1.10.11/docker-18.06.1/dcos_images.yaml
+++ b/coreos/2023.4.0/aws/DCOS-1.10.11/docker-18.06.1/dcos_images.yaml
@@ -1,0 +1,15 @@
+ap-northeast-1: ami-00ceab1989ca1e1a9
+ap-northeast-2: ami-00114ad48dd718375
+ap-south-1: ami-0ad4f1cd6e7f37037
+ap-southeast-1: ami-0b5d8b6ef6efec39d
+ap-southeast-2: ami-0070c01f015689d4c
+ca-central-1: ami-0b04288686b2c7ece
+eu-central-1: ami-071ad6b9325dc0212
+eu-west-1: ami-0900adb8d82635f9a
+eu-west-2: ami-049fee7368f726d2d
+eu-west-3: ami-0cb8041d417ad57f0
+sa-east-1: ami-093cdbc9b1fcdc1ca
+us-east-1: ami-0ec6abe8fed8e52f6
+us-east-2: ami-04751692c645dd136
+us-west-1: ami-0626241a02f9cf5f5
+us-west-2: ami-0d4772592c73d94b5

--- a/coreos/2023.4.0/aws/DCOS-1.10.11/docker-18.06.1/desired_cluster_profile.tfvars
+++ b/coreos/2023.4.0/aws/DCOS-1.10.11/docker-18.06.1/desired_cluster_profile.tfvars
@@ -1,0 +1,18 @@
+os = "coreos"
+user = "core"
+aws_region = "us-west-2"
+
+aws_bootstrap_instance_type = "m3.large"
+aws_master_instance_type = "m4.xlarge"
+aws_agent_instance_type = "m4.xlarge"
+aws_public_agent_instance_type = "m4.xlarge"
+
+ssh_key_name = "dcos-images"
+# Inbound Master Access
+admin_cidr = "0.0.0.0/0"
+
+num_of_masters = "1"
+num_of_private_agents = "5"
+num_of_public_agents = "1"
+
+custom_dcos_download_path = "https://downloads.dcos.io/dcos/stable/1.10.11/dcos_generate_config.sh"

--- a/coreos/2023.4.0/aws/DCOS-1.10.11/docker-18.06.1/install_dcos_prerequisites.sh
+++ b/coreos/2023.4.0/aws/DCOS-1.10.11/docker-18.06.1/install_dcos_prerequisites.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+sudo systemctl disable locksmithd
+sudo systemctl stop locksmithd
+sudo systemctl restart docker # Restarting docker to ensure its ready. Seems like its not during first usage.

--- a/coreos/2023.4.0/aws/DCOS-1.10.11/docker-18.06.1/packer.json
+++ b/coreos/2023.4.0/aws/DCOS-1.10.11/docker-18.06.1/packer.json
@@ -8,13 +8,13 @@
     {
       "type": "amazon-ebs",
       "instance_type": "m4.xlarge",
-      "source_ami": "ami-0b0f4f5f0c8c1a797",
+      "source_ami": "ami-025acbb0fb1db6a27",
       "region": "us-west-2",
       "access_key": "{{user `aws_access_key`}}",
       "secret_key": "{{user `aws_secret_key`}}",
       "ssh_username": "core",
       "ami_name": "dcos-ami-{{timestamp}}",
-      "ami_description": "coreos/1967.6.0/aws/DCOS-1.10.11/docker-18.06.1",
+      "ami_description": "coreos/2023.4.0/aws/DCOS-1.10.11/docker-18.06.1",
       "ami_regions": [
         "ap-northeast-1",
         "ap-northeast-2",

--- a/coreos/2023.4.0/aws/DCOS-1.10.11/docker-18.06.1/packer.json
+++ b/coreos/2023.4.0/aws/DCOS-1.10.11/docker-18.06.1/packer.json
@@ -1,0 +1,56 @@
+{
+  "variables": {
+    "aws_access_key": "{{env `AWS_ACCESS_KEY_ID`}}",
+    "aws_secret_key": "{{env `AWS_SECRET_ACCESS_KEY`}}",
+    "region":         "us-west-2"
+  },
+  "builders": [
+    {
+      "type": "amazon-ebs",
+      "instance_type": "m4.xlarge",
+      "source_ami": "ami-0b0f4f5f0c8c1a797",
+      "region": "us-west-2",
+      "access_key": "{{user `aws_access_key`}}",
+      "secret_key": "{{user `aws_secret_key`}}",
+      "ssh_username": "core",
+      "ami_name": "dcos-ami-{{timestamp}}",
+      "ami_description": "coreos/1967.6.0/aws/DCOS-1.10.11/docker-18.06.1",
+      "ami_regions": [
+        "ap-northeast-1",
+        "ap-northeast-2",
+        "ap-south-1",
+        "ap-southeast-1",
+        "ap-southeast-2",
+        "ca-central-1",
+        "eu-central-1",
+        "eu-west-1",
+        "eu-west-2",
+        "eu-west-3",
+        "sa-east-1",
+        "us-east-1",
+        "us-east-2",
+        "us-west-1",
+        "us-west-2"
+      ],
+      "ami_groups": "all",
+      "ebs_optimized": true,
+      "ena_support": true,
+      "sriov_support": true
+    }
+  ],
+  "provisioners": [
+    {
+      "type": "shell",
+      "script": "./install_dcos_prerequisites.sh"
+    }
+  ],
+  "post-processors": [
+    [
+      {
+        "output": "packer_build_history.json",
+        "strip_path": true,
+        "type": "manifest"
+      }
+    ]
+  ]
+}

--- a/coreos/2023.4.0/aws/DCOS-1.10.11/docker-18.06.1/packer_build_history.json
+++ b/coreos/2023.4.0/aws/DCOS-1.10.11/docker-18.06.1/packer_build_history.json
@@ -1,0 +1,13 @@
+{
+  "builds": [
+    {
+      "name": "amazon-ebs",
+      "builder_type": "amazon-ebs",
+      "build_time": 1552289513,
+      "files": null,
+      "artifact_id": "ap-northeast-1:ami-00ceab1989ca1e1a9,ap-northeast-2:ami-00114ad48dd718375,ap-south-1:ami-0ad4f1cd6e7f37037,ap-southeast-1:ami-0b5d8b6ef6efec39d,ap-southeast-2:ami-0070c01f015689d4c,ca-central-1:ami-0b04288686b2c7ece,eu-central-1:ami-071ad6b9325dc0212,eu-west-1:ami-0900adb8d82635f9a,eu-west-2:ami-049fee7368f726d2d,eu-west-3:ami-0cb8041d417ad57f0,sa-east-1:ami-093cdbc9b1fcdc1ca,us-east-1:ami-0ec6abe8fed8e52f6,us-east-2:ami-04751692c645dd136,us-west-1:ami-0626241a02f9cf5f5,us-west-2:ami-0d4772592c73d94b5",
+      "packer_run_uuid": "c1e7ffa3-411a-9c8d-8f98-416fc971186a"
+    }
+  ],
+  "last_run_uuid": "c1e7ffa3-411a-9c8d-8f98-416fc971186a"
+}

--- a/coreos/2023.4.0/aws/DCOS-1.10.11/docker-18.06.1/publish_and_test_config.yaml
+++ b/coreos/2023.4.0/aws/DCOS-1.10.11/docker-18.06.1/publish_and_test_config.yaml
@@ -1,0 +1,23 @@
+# options: packer_build, dcos_installation, integration_tests, never. Default is dcos_installation. For more details, see README
+publish_dcos_images_after: dcos_installation
+run_framework_tests: false
+run_integration_tests: true
+tests_to_run:
+  - test_applications.py
+  - test_auth.py
+  - test_composition.py
+  - test_dcos_diagnostics.py
+  - test_dcos_log.py
+  - test_endpoints.py
+  - test_helpers.py
+  - test_mesos.py
+  - test_meta.py
+  - test_metrics.py
+  - test_misc.py
+  - test_networking.py
+  - test_rexray.py
+  - test_rlimit.py
+  - test_service_discovery.py
+  - test_sysctl.py
+  - test_ucr.py
+  - test_units.py

--- a/coreos/2023.4.0/aws/DCOS-1.10.11/docker-18.06.1/setup.sh
+++ b/coreos/2023.4.0/aws/DCOS-1.10.11/docker-18.06.1/setup.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+sudo systemctl disable locksmithd
+sudo systemctl stop locksmithd
+sudo systemctl mask locksmithd
+
+sudo systemctl disable update-engine # Disabling automatic updates.
+sudo systemctl stop update-engine
+sudo systemctl mask update-engine
+sudo systemctl restart docker # Restarting docker to ensure its ready. Seems like its not during first usage

--- a/coreos/2023.4.0/aws/base_images.json
+++ b/coreos/2023.4.0/aws/base_images.json
@@ -1,0 +1,22 @@
+{
+  "ap-northeast-1": "ami-003b3a37a48d799cf",
+  "ap-northeast-2": "ami-0c2d3bd39b13c3b2d",
+  "ap-south-1": "ami-0bd5eb3e67407e0df",
+  "ap-southeast-1": "ami-07aafbd1f2a182cd4",
+  "ap-southeast-2": "ami-0cb589c5f6134f078",
+  "ca-central-1": "ami-0952a9471ff71919e",
+  "cn-north-1": "ami-0caaf17a3032c1b56",
+  "cn-northwest-1": "ami-0a863f3b0a0720e6a",
+  "eu-central-1": "ami-015e6cb33a709348e",
+  "eu-north-1": "ami-0fc64edffdfc5e7e5",
+  "eu-west-1": "ami-04d747d892ccd652a",
+  "eu-west-2": "ami-056a316ba69c9d9e8",
+  "eu-west-3": "ami-026d41122f47f745e",
+  "sa-east-1": "ami-0e9521088a80c2a02",
+  "us-east-1": "ami-09d5d3bcd3e0e5c30",
+  "us-east-2": "ami-02accfa372062664b",
+  "us-gov-east-1": "ami-007dd78814dd81561",
+  "us-gov-west-1": "ami-07600866",
+  "us-west-1": "ami-0481a60675f6ea007",
+  "us-west-2": "ami-025acbb0fb1db6a27"
+}


### PR DESCRIPTION
Results: 127 passed, 5 skipped, 1 warnings in 2380.16 seconds