### PR TITLE
Qualifying DC/OS 1.11.10 against CoreOS 2023.5.0 - new

### DIFF
--- a/centos/7.4/aws/DCOS-1.11.10/docker-18.09.2-ce/selinux_disabled/publish_and_test_config.yaml
+++ b/centos/7.4/aws/DCOS-1.11.10/docker-18.09.2-ce/selinux_disabled/publish_and_test_config.yaml
@@ -2,23 +2,3 @@
 publish_dcos_images_after: dcos_installation
 run_framework_tests: false
 run_integration_tests: true
-tests_to_run:
-  - test_applications.py
-  - test_auth.py
-  - test_composition.py
-  - test_dcos_diagnostics.py
-  - test_dcos_log.py
-  - test_endpoints.py
-  - test_helpers.py
-  - test_mesos.py
-  - test_meta.py
-  - test_metrics.py
-  - test_metronome.py
-  - test_misc.py
-  - test_networking.py
-  - test_rexray.py
-  - test_rlimit.py
-  - test_service_discovery.py
-  - test_sysctl.py
-  - test_ucr.py
-  - test_units.py

--- a/coreos/2023.5.0/aws/DCOS-1.11.10/docker-18.06.1/cluster_profile.tfvars
+++ b/coreos/2023.5.0/aws/DCOS-1.11.10/docker-18.06.1/cluster_profile.tfvars
@@ -1,5 +1,3 @@
-os = "rhel"
-user = "ec2-user"
 aws_region = "us-west-2"
 
 aws_bootstrap_instance_type = "m5.large"
@@ -16,3 +14,7 @@ num_of_private_agents = "2"
 num_of_public_agents = "1"
 
 custom_dcos_download_path = "https://downloads.dcos.io/dcos/stable/1.11.10/dcos_generate_config.sh"
+enable_os_setup_script = false
+
+owner = "dcos-images"
+expiration = "3h"

--- a/coreos/2023.5.0/aws/DCOS-1.13.0/docker-18.06.1/packer.json
+++ b/coreos/2023.5.0/aws/DCOS-1.13.0/docker-18.06.1/packer.json
@@ -16,26 +16,65 @@
       "ami_name": "dcos-ami-{{timestamp}}",
       "ami_description": "coreos/2023.5.0/aws/DCOS-1.13.0/docker-18.06.1",
       "ami_regions": [
-        "ap-northeast-1",
-        "ap-northeast-2",
-        "ap-south-1",
-        "ap-southeast-1",
-        "ap-southeast-2",
-        "ca-central-1",
-        "eu-central-1",
-        "eu-west-1",
-        "eu-west-2",
-        "eu-west-3",
-        "sa-east-1",
         "us-east-1",
-        "us-east-2",
-        "us-west-1",
         "us-west-2"
       ],
       "ami_groups": "all",
       "ebs_optimized": true,
       "ena_support": true,
-      "sriov_support": true
+      "sriov_support": true,
+      "ami_block_device_mappings": [
+        {
+          "device_name": "/dev/sde",
+          "volume_type": "gp2",
+          "volume_size": 50,
+          "delete_on_termination": true
+        },
+        {
+          "device_name": "/dev/sdf",
+          "volume_type": "gp2",
+          "volume_size": 100,
+          "delete_on_termination": true
+        },
+        {
+          "device_name": "/dev/sdg",
+          "volume_type": "gp2",
+          "volume_size": 50,
+          "delete_on_termination": true
+        },
+        {
+          "device_name": "/dev/sdh",
+          "volume_type": "gp2",
+          "volume_size": 20,
+          "delete_on_termination": true
+        }
+      ],
+      "launch_block_device_mappings": [
+        {
+          "device_name": "/dev/sde",
+          "volume_type": "gp2",
+          "volume_size": 50,
+          "delete_on_termination": true
+        },
+        {
+          "device_name": "/dev/sdf",
+          "volume_type": "gp2",
+          "volume_size": 100,
+          "delete_on_termination": true
+        },
+        {
+          "device_name": "/dev/sdg",
+          "volume_type": "gp2",
+          "volume_size": 50,
+          "delete_on_termination": true
+        },
+        {
+          "device_name": "/dev/sdh",
+          "volume_type": "gp2",
+          "volume_size": 20,
+          "delete_on_termination": true
+        }
+      ]
     }
   ],
   "provisioners": [

--- a/coreos/2023.5.0/aws/base_images.json
+++ b/coreos/2023.5.0/aws/base_images.json
@@ -1,22 +1,3 @@
 {
-  "ap-northeast-1": "ami-0d3a9785820124591",
-  "ap-northeast-2": "ami-03230b2fa6af112bf",
-  "ap-south-1": "ami-0b85fd1356963d2ee",
-  "ap-southeast-1": "ami-0f8a9aa9857d8af7e",
-  "ap-southeast-2": "ami-0e87752a1d331823a",
-  "ca-central-1": "ami-0c0100bac23bb1d39",
-  "cn-north-1": "ami-01e99c7e0a343d325",
-  "cn-northwest-1": "ami-0773341917796083a",
-  "eu-central-1": "ami-012abdf0d2781f0a5",
-  "eu-north-1": "ami-09fbda19ac2fc6c3f",
-  "eu-west-1": "ami-01f5fbceb7a9fa4d0",
-  "eu-west-2": "ami-069966bea0809e21d",
-  "eu-west-3": "ami-0194c504244182155",
-  "sa-east-1": "ami-0cd830cc037613a7d",
-  "us-east-1": "ami-08e58b93705fb503f",
-  "us-east-2": "ami-03172282aaa2899be",
-  "us-gov-east-1": "ami-0ff9e298ea0bacf53",
-  "us-gov-west-1": "ami-e7f59e86",
-  "us-west-1": "ami-08d3e245ebf4d560f",
   "us-west-2": "ami-0a4f49b2488e15346"
 }


### PR DESCRIPTION
Results: 1 failed, 131 passed, 6 skipped, 4 xpassed, 3 warnings in 2720.32 seconds
Failed test: test_blkio_stats
JIRA: https://jira.mesosphere.com/browse/DCOS-52126