### PR TITLE
Qualifying DC/OS 1.13.3 against CoreOS 2079.6.0 and Docker 18.06.3

### DIFF
--- a/coreos/2079.6.0/aws/DCOS-1.13.3/docker-18.06.3/cluster_profile.tfvars
+++ b/coreos/2079.6.0/aws/DCOS-1.13.3/docker-18.06.3/cluster_profile.tfvars
@@ -1,0 +1,20 @@
+aws_region = "us-west-2"
+
+aws_bootstrap_instance_type = "m5.large"
+aws_master_instance_type = "m5.xlarge"
+aws_agent_instance_type = "m5.xlarge"
+aws_public_agent_instance_type = "m5.xlarge"
+
+ssh_key_name = "dcos-images"
+# Inbound Master Access
+admin_cidr = "0.0.0.0/0"
+
+num_of_masters = "1"
+num_of_private_agents = "2"
+num_of_public_agents = "1"
+
+custom_dcos_download_path = "https://downloads.dcos.io/dcos/testing/1.13.3/dcos_generate_config.sh"
+enable_os_setup_script = false
+
+owner = "dcos-images"
+expiration = "2h"

--- a/coreos/2079.6.0/aws/DCOS-1.13.3/docker-18.06.3/dcos_images.yaml
+++ b/coreos/2079.6.0/aws/DCOS-1.13.3/docker-18.06.3/dcos_images.yaml
@@ -1,0 +1,2 @@
+us-east-1: ami-0b601b7cfd473360d
+us-west-2: ami-0b8d1470a9dd55d5f

--- a/coreos/2079.6.0/aws/DCOS-1.13.3/docker-18.06.3/install_dcos_prerequisites.sh
+++ b/coreos/2079.6.0/aws/DCOS-1.13.3/docker-18.06.3/install_dcos_prerequisites.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+sudo systemctl disable locksmithd
+sudo systemctl stop locksmithd
+sudo systemctl mask locksmithd
+
+sudo systemctl disable update-engine # Disabling automatic updates.
+sudo systemctl stop update-engine
+sudo systemctl mask update-engine
+
+sudo mkdir -p /etc/systemd/system/docker.service.d
+sudo tee /etc/systemd/system/docker.service.d/override.conf <<- EOF
+[Service]
+ExecStart=
+ExecStart=/usr/bin/dockerd -H fd://
+EOF
+
+sudo systemctl restart docker # Restarting docker to ensure its ready. Seems like its not during first usage

--- a/coreos/2079.6.0/aws/DCOS-1.13.3/docker-18.06.3/install_dss_modules.sh
+++ b/coreos/2079.6.0/aws/DCOS-1.13.3/docker-18.06.3/install_dss_modules.sh
@@ -1,0 +1,9 @@
+set -ex
+
+# load the modules
+sudo modprobe dm_raid
+sudo modprobe raid1
+
+# Load RAID-related kernel modules on boot
+sudo bash -c "echo 'dm_raid' >> /etc/modules-load.d/modules.conf"
+sudo bash -c "echo 'raid1' >> /etc/modules-load.d/modules.conf"

--- a/coreos/2079.6.0/aws/DCOS-1.13.3/docker-18.06.3/packer.json
+++ b/coreos/2079.6.0/aws/DCOS-1.13.3/docker-18.06.3/packer.json
@@ -1,0 +1,48 @@
+{
+  "variables": {
+    "aws_access_key": "{{env `AWS_ACCESS_KEY_ID`}}",
+    "aws_secret_key": "{{env `AWS_SECRET_ACCESS_KEY`}}",
+    "region":         "us-west-2"
+  },
+  "builders": [
+    {
+      "type": "amazon-ebs",
+      "instance_type": "m5.xlarge",
+      "source_ami": "ami-023d3b5f74bd89f9b",
+      "region": "us-west-2",
+      "access_key": "{{user `aws_access_key`}}",
+      "secret_key": "{{user `aws_secret_key`}}",
+      "ssh_username": "core",
+      "ami_name": "dcos-ami-{{timestamp}}",
+      "ami_description": "coreos/2079.6.0/aws/DCOS-1.13.3/docker-18.06.3",
+      "ami_regions": [
+        "us-east-1",
+        "us-west-2"
+      ],
+      "ami_groups": "all",
+      "associate_public_ip_address": true,
+      "ebs_optimized": true,
+      "ena_support": true,
+      "sriov_support": true
+    }
+  ],
+  "provisioners": [
+    {
+      "type": "shell",
+      "script": "./install_dcos_prerequisites.sh"
+    },
+    {
+      "type": "shell",
+      "script": "./install_dss_modules.sh"
+    }
+  ],
+  "post-processors": [
+    [
+      {
+        "output": "packer_build_history.json",
+        "strip_path": true,
+        "type": "manifest"
+      }
+    ]
+  ]
+}

--- a/coreos/2079.6.0/aws/DCOS-1.13.3/docker-18.06.3/packer_build_history.json
+++ b/coreos/2079.6.0/aws/DCOS-1.13.3/docker-18.06.3/packer_build_history.json
@@ -1,0 +1,13 @@
+{
+  "builds": [
+    {
+      "name": "amazon-ebs",
+      "builder_type": "amazon-ebs",
+      "build_time": 1563369969,
+      "files": null,
+      "artifact_id": "us-east-1:ami-0b601b7cfd473360d,us-west-2:ami-0b8d1470a9dd55d5f",
+      "packer_run_uuid": "c779d611-a274-5e66-3c78-88778b3a5429"
+    }
+  ],
+  "last_run_uuid": "c779d611-a274-5e66-3c78-88778b3a5429"
+}

--- a/coreos/2079.6.0/aws/DCOS-1.13.3/docker-18.06.3/publish_and_test_config.yaml
+++ b/coreos/2079.6.0/aws/DCOS-1.13.3/docker-18.06.3/publish_and_test_config.yaml
@@ -1,0 +1,4 @@
+# options: packer_build, dcos_installation, integration_tests, never. Default is dcos_installation. For more details, see README
+publish_dcos_images_after: integration_tests
+run_framework_tests: false
+run_integration_tests: true

--- a/coreos/2079.6.0/aws/DCOS-1.13.3/docker-18.06.3/publish_and_test_config.yaml
+++ b/coreos/2079.6.0/aws/DCOS-1.13.3/docker-18.06.3/publish_and_test_config.yaml
@@ -2,3 +2,5 @@
 publish_dcos_images_after: integration_tests
 run_framework_tests: false
 run_integration_tests: true
+tests_to_run:
+  - -k 'not test_executor_metrics_metadata'


### PR DESCRIPTION
JIRA: https://jira.mesosphere.com/browse/DCOS-56230
Results: 208 passed, 8 skipped, 1 deselected, 2 warnings in 3995.62 seconds